### PR TITLE
Add central logging for filters

### DIFF
--- a/repokid/filters/blacklist/__init__.py
+++ b/repokid/filters/blacklist/__init__.py
@@ -17,5 +17,4 @@ class BlacklistFilter(Filter):
         for role in input_list:
             if role['RoleName'].lower() in self.overridden_role_names:
                 blacklisted_roles.append(role)
-                LOGGER.info('{name} in the role blacklist'.format(name=role['RoleName']))
         return blacklisted_roles

--- a/repokid/filters/lambda/__init__.py
+++ b/repokid/filters/lambda/__init__.py
@@ -8,6 +8,5 @@ class LambdaFilter(Filter):
 
         for role in input_list:
             if 'lambda' in str(role['AssumeRolePolicyDocument']).lower():
-                LOGGER.info('{name} looks like a lambda role.'.format(name=role['RoleName']))
                 lambda_roles.append(role)
         return list(lambda_roles)

--- a/repokid/repokid.py
+++ b/repokid/repokid.py
@@ -220,6 +220,7 @@ def update_role_cache(account_number):
         filtered_list = plugin.apply(roles)
         class_name = plugin.__class__.__name__
         for role in filtered_list:
+            LOGGER.info('Role {} filtered by {}'.format(role['RoleName'], class_name))
             filtered_roles_list[role['RoleId']].append(class_name)
 
     roledata.update_filtered_roles(filtered_roles_list)


### PR DESCRIPTION
This commit moves logging of applied filters out of the filters
themselves.  Plugins that want additional logging (like age
details) can still log, but an info level event will occur each
time a role is filtered by a plugin.