### PR TITLE
Change Role to be a class and performance improvements

### DIFF
--- a/repokid/filters/age/__init__.py
+++ b/repokid/filters/age/__init__.py
@@ -17,8 +17,8 @@ class AgeFilter(Filter):
 
         too_young = []
         for role in input_list:
-            if role['CreateDate'] > now - ago:
+            if role.create_date > now - ago:
                 LOGGER.info('Role {name} created too recently to cleanup. ({date})'.format(
-                            name=role['RoleName'], date=role['CreateDate']))
+                            name=role.role_name, date=role.create_date))
                 too_young.append(role)
         return too_young

--- a/repokid/filters/blacklist/__init__.py
+++ b/repokid/filters/blacklist/__init__.py
@@ -1,19 +1,23 @@
 from repokid.repokid import Filter
-from repokid.repokid import CUR_ACCOUNT_NUMBER
+from repokid.repokid import LOGGER
 
 
 class BlacklistFilter(Filter):
     def __init__(self, config=None):
         self.config = config
 
+        current_account = config.get('current_account') or None
+        if not current_account:
+            LOGGER.error('Unable to get current account for Blacklist Filter')
+
         overridden_role_names = set()
-        overridden_role_names.update([rolename.lower() for rolename in config.get(CUR_ACCOUNT_NUMBER, [])])
+        overridden_role_names.update([rolename.lower() for rolename in config.get(current_account, [])])
         overridden_role_names.update([rolename.lower() for rolename in config.get('all', [])])
         self.overridden_role_names = overridden_role_names
 
     def apply(self, input_list):
         blacklisted_roles = []
         for role in input_list:
-            if role['RoleName'].lower() in self.overridden_role_names:
+            if role.role_name.lower() in self.overridden_role_names:
                 blacklisted_roles.append(role)
         return blacklisted_roles

--- a/repokid/filters/lambda/__init__.py
+++ b/repokid/filters/lambda/__init__.py
@@ -6,6 +6,6 @@ class LambdaFilter(Filter):
         lambda_roles = []
 
         for role in input_list:
-            if 'lambda' in str(role['AssumeRolePolicyDocument']).lower():
+            if 'lambda' in str(role.assume_role_policy_document).lower():
                 lambda_roles.append(role)
         return list(lambda_roles)

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -1,0 +1,67 @@
+class Role(object):
+    def __init__(self, role_dict):
+        self.aa_data = role_dict.get('AAData', {})
+        self.active = role_dict.get('Active', True)
+        self.arn = role_dict.get('Arn', None)
+        self.assume_role_policy_document = role_dict.get('AssumeRolePolicyDocument', None)
+        self.create_date = role_dict.get('CreateDate', None)
+        self.disqualified_by = role_dict.get('DisqualifiedBy', [])
+        self.policies = role_dict.get('Policies', [])
+        self.repoable_permissions = role_dict.get('RepoablePermissions', 0)
+        self.repoable_services = role_dict.get('RepoableServices', [])
+        self.repoed = role_dict.get('Repoed', '')
+        self.role_id = role_dict.get('RoleId', None)
+        self.role_name = role_dict.get('RoleName', None)
+        self.stats = role_dict.get('Stats', [])
+        self.total_permissions = role_dict.get('TotalPermissions', 0)
+
+        self.account = role_dict.get('Account', None) or self.arn.split(':')[4] if self.arn else None
+
+    def as_dict(self):
+        return {'AAData': self.aa_data,
+                'Account': self.account,
+                'Active': self.active,
+                'Arn': self.arn,
+                'AssumeRolePolicyDocument': self.assume_role_policy_document,
+                'CreateDate': self.create_date,
+                'DisqualifiedBy': self.disqualified_by,
+                'Policies': self.policies,
+                'RepoablePermissions': self.repoable_permissions,
+                'RepoableServices': self.repoable_services,
+                'Repoed': self.repoed,
+                'RoleId': self.role_id,
+                'RoleName': self.role_name,
+                'Stats': self.stats,
+                'TotalPermissions': self.total_permissions}
+
+    def __eq__(self, other):
+        return self.role_id == other.role_id
+
+    def __hash__(self):
+        return hash(self.role_id)
+
+
+class Roles(object):
+    def __init__(self, role_object_list):
+        self.roles = role_object_list
+
+    def __getitem__(self, index):
+        return self.roles[index]
+
+    def __len__(self):
+        return len(self.roles)
+
+    def role_id_list(self):
+        return [role.role_id for role in self.roles]
+
+    def get_by_id(self, id):
+        try:
+            return self.filter(role_id=id)[0]
+        except IndexError:
+            return None
+
+    def filter(self, **kwargs):
+        roles = self.roles
+        for arg, value in kwargs.items():
+            roles = [role for role in roles if getattr(role, arg, None) == value]
+        return roles


### PR DESCRIPTION
This (large) commit refacts Repokid to use a class instead of
passing dict values around everywhere.  We also now use local
copies of data whenever possible instead of retrieving from
Dynamo.  When we do retrieve from Dynamo we retrieve the smallest
amount of data possible.