### PR TITLE
Two bug fixes

### DIFF
--- a/repokid/repokid.py
+++ b/repokid/repokid.py
@@ -214,16 +214,14 @@ def update_role_cache(account_number):
     for plugin in CONFIG.get('active_filters'):
         plugins.load_plugin(plugin)
 
-    filtered_roles = set()
     for plugin in plugins.filter_plugins:
         filtered_list = plugin.apply(roles)
         class_name = plugin.__class__.__name__
         for role in filtered_list:
-            filtered_roles.add(role)
             LOGGER.info('Role {} filtered by {}'.format(role.role_name, class_name))
             roles.get_by_id(role.role_id).disqualified_by.append(class_name)
 
-    roledata.update_filtered_roles(filtered_roles)
+    roledata.update_filtered_roles(roles)
 
     LOGGER.info('Getting data from Aardvark')
     aardvark_data = _get_aardvark_data(account_number)
@@ -511,7 +509,7 @@ def _get_aardvark_data(account_number):
             sys.exit(1)
         else:
             if(r_aardvark.status_code != 200):
-                LOGGER.error('Unable to get Aardvark data: {}'.format(e))
+                LOGGER.error('Unable to get Aardvark data')
                 sys.exit(1)
 
             response_data.update(r_aardvark.json())

--- a/tests/test_repokid.py
+++ b/tests/test_repokid.py
@@ -184,11 +184,9 @@ class TestRepokid(object):
         assert mock_find_and_mark_inactive.mock_calls == [call('123456789012',
                                                           [Role(ROLES[0]), Role(ROLES[1]), Role(ROLES[2])])]
 
-        filtered_roles = set()
-        filtered_roles.add(Role(ROLES[2]))
-        assert mock_update_filtered_roles.mock_calls == [call(filtered_roles)]
-
         roles = Roles([Role(ROLES[0]), Role(ROLES[1]), Role(ROLES[2])])
+        assert mock_update_filtered_roles.mock_calls == [call(roles)]
+
         assert mock_update_aardvark_data.mock_calls == [call('123456789012', AARDVARK_DATA, roles)]
 
         # TODO: validate total permission, repoable, etc are getting updated properly


### PR DESCRIPTION
This commit fixes two bugs.  The first bug would prevent roles
which had been previously filtered from becoming unfiltered.  By
being too eager to save Dynamo operations we were updating only
roles with filters, which had the unfortunate side effect that
roles can't become unfiltered.

The other bug was attempting to use a exception details in an
error that wasn't triggered by an exception.