### PR TITLE
A few enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ RepokidRole:
         "iam:ListInstanceProfilesForRole",
         "iam:ListRolePolicies",
         "iam:ListRoles",
-        "iam:PutRolePolicy"
+        "iam:PutRolePolicy",
+        "iam:UpdateRoleDescription"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 
 
 def init_config():

--- a/repokid/filters/optout/__init__.py
+++ b/repokid/filters/optout/__init__.py
@@ -1,4 +1,4 @@
-import time.time
+import time
 
 from repokid.cli.repokid_cli import Filter
 

--- a/repokid/tests/test_roledata.py
+++ b/repokid/tests/test_roledata.py
@@ -140,7 +140,7 @@ class TestRoledata(object):
 
         no_repo_permissions = {'service_4:action_1': time.time()-1, 'service_4:action_2': time.time()+1000}
 
-        repoable_permissions = repokid.utils.roledata._get_repoable_permissions(permissions, aa_data,
+        repoable_permissions = repokid.utils.roledata._get_repoable_permissions('test_name', permissions, aa_data,
                                                                                 no_repo_permissions, minimum_age)
         # service_1:action_3 and action_4 are unsupported actions, service_2 is an unsupported service, service_3
         # was used too recently, service_4 action 2 is in no_repo_permissions and not expired


### PR DESCRIPTION
- Create a new function that can update individual role data.
  This is useful so we can get an accurate count of repoable, etc
  permissions after a repo or rollback.
- Find roles by name using a secondary index now (should improve
  performance significantly)
- Change description when a role is repoed to include the date
- When showing warnings about a permission being on the no repo
  list, show info instead and show the role name
- Only update stats when the count or repoable services are
  different than before
- Fix a bug where display role fails if a bad role name is given
- Fix a bug in the OptOut filter