### PR TITLE
Fixing a bug with same role name in multiple accounts

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.5'
+__version__ = '0.7.6'
 
 
 def init_config():

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -445,6 +445,8 @@ def update_role_cache(account_number, dynamo_table, config, hooks):
     LOGGER.info('Calculating repoable permissions and services')
     roledata._calculate_repo_scores(roles, config['filter_config']['AgeFilter']['minimum_age'], hooks)
     for role in roles:
+        if role.role_name == 'Monterey':
+            import pdb; pdb.set_trace()
         set_role_data(dynamo_table, role.role_id, {'TotalPermissions': role.total_permissions,
                                                    'RepoablePermissions': role.repoable_permissions,
                                                    'RepoableServices': role.repoable_services})

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -143,8 +143,8 @@ def find_role_in_cache(dynamo_table, account_number, role_name):
 
     if len(role_id_candidates) > 1:
         for role_id in role_id_candidates:
-            role_data = get_role_data(dynamo_table, role_id, fields=['Active'])
-            if role_data['Active']:
+            role_data = get_role_data(dynamo_table, role_id, fields=['Account', 'Active'])
+            if role_data['Account'] == account_number and role_data['Active']:
                 return role_id
     elif len(role_id_candidates) == 1:
         return role_id_candidates[0]

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -181,10 +181,9 @@ def update_role_data(dynamo_table, account_number, role, current_policy, source=
         update_opt_out(dynamo_table, role)
         set_role_data(dynamo_table, role.role_id, {'Refreshed': datetime.datetime.utcnow().isoformat()})
 
-        # Update all data from Dynamo except CreateDate (it's in the wrong format)
-        current_role_data = get_role_data(dynamo_table, role.role_id)
-        current_role_data.pop('CreateDate')
-        role.set_attributes(current_role_data)
+        cur_role_data = get_role_data(dynamo_table, role.role_id, fields=['OptOut', 'Policies'])
+        role.opt_out = cur_role_data.get('OptOut', {})
+        role.policies = cur_role_data.get('Policies', [])
 
 
 def update_stats(dynamo_table, roles, source='Scan'):


### PR DESCRIPTION
The find_role_in_cache function had a bug that would return the
wrong role if multiple existed across accounts because it wasn't
checking the account number matched.