### PR TITLE
Allow permissions to be listed in repoable services too

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.7'
+__version__ = '0.7.8'
 
 
 def init_config():

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -586,7 +586,7 @@ def display_role(account_number, role_name, dynamo_table, config, hooks):
                                                                   config['filter_config']['AgeFilter']['minimum_age'],
                                                                   hooks)
 
-    print "Repoable services:"
+    print "Repoable services and permissions"
     headers = ['Service', 'Action', 'Repoable']
     rows = []
     for permission in permissions:

--- a/repokid/dispatcher/__init__.py
+++ b/repokid/dispatcher/__init__.py
@@ -28,10 +28,18 @@ def list_repoable_services(dynamo_table, message):
                                                                                             message.account))
     else:
         role_data = dynamo.get_role_data(dynamo_table, role_id, fields=['RepoableServices'])
+
+        (repoable_permissions, repoable_services) = roledata._convert_repoed_service_to_sorted_perms_and_services(
+            role_data['RepoableServices'])
+
         repoable_services = role_data['RepoableServices']
         return ResponderReturn(successful=True,
-                               return_message='Repoable services from role {} in account {}: {}'.format(
-                                    message.role_name, message.account, repoable_services))
+                               return_message=('Role {} in account {} has:\n    Repoable Services: \n{}'
+                                               '\n\n    Repoable Permissions: \n{}'.format(
+                                                message.role_name,
+                                                message.account,
+                                                '\n'.join([service for service in repoable_services]),
+                                                '\n'.join([perm for perm in repoable_permissions]))))
 
 
 @implements_command('list_role_rollbacks')

--- a/repokid/tests/test_roledata.py
+++ b/repokid/tests/test_roledata.py
@@ -213,3 +213,19 @@ class TestRoledata(object):
 
         new_perms = repokid.utils.roledata.find_newly_added_permissions(old_policy, new_policy)
         assert new_perms == set(['ec2:allocatehosts', 'ec2:associateaddress'])
+
+    def test_convert_repoable_perms_to_perms_and_services(self):
+        all_perms = ['a:j', 'a:k', 'b:l', 'c:m', 'c:n']
+        repoable_perms = ['b:l', 'c:m']
+        expected_repoed_services = ['b']
+        expected_repoed_permissions = ['c:m']
+        assert (repokid.utils.roledata._convert_repoable_perms_to_perms_and_services(all_perms, repoable_perms) ==
+                (expected_repoed_permissions, expected_repoed_services))
+
+    def test_convert_repoed_service_to_sorted_perms_and_services(self):
+        repoed_services = ['route53', 'ec2', 's3:abc', 'dynamodb:def', 'ses:ghi', 'ses:jkl']
+        expected_services = ['ec2', 'route53']
+        expected_permissions = ['dynamodb:def', 's3:abc', 'ses:ghi', 'ses:jkl']
+        assert repokid.utils.roledata._convert_repoed_service_to_sorted_perms_and_services(repoed_services) == (
+            expected_permissions, expected_services
+        )


### PR DESCRIPTION
This commit changes repoable permissions to allow storing repoable
permissions too.  Access Advisor only gives information for the
whole service level, so Repokid was designed to store a list of
repoable services.  Now with additional data sources we might have
individual permissions being repoed too so we can store these in
the list.  To support this we've created two new utility
functions:
 - convert repoable permissions list to services and permissions
 - split the repoable service back to perms and services list