### PR TITLE
Bug/tr 46 fix pypi install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Pushing New Versions to Pypi
 ----------------------------
 For the majority of contributors, this will not be a huge factor, however, for those deploying new versions, the instructions are as follows:
 1. Ensure you have `twine` installed, this is part of the requirements file, so if you've installed via the recommended paths, you should be fine.
-2. Edit the version number present in the __`__repokid/init.py`:
+2. Edit the version number present in the `repokid/init.py`:
 
         $ vim repokid/__init__.py
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,23 +22,23 @@ Please also verify that the changes you've made work as expected locally.
 Pushing New Versions to Pypi
 ----------------------------
 For the majority of contributors, this will not be a huge factor, however, for those deploying new versions, the instructions are as follows:
-1. Ensure you have `twine` installed, this is part of the requirements file, so if you've installed via the recommended paths, you should be fine..
-2. Edit the version number present in the __`__repokid/___init___.py`:
-        ```
+1. Ensure you have `twine` installed, this is part of the requirements file, so if you've installed via the recommended paths, you should be fine.
+2. Edit the version number present in the __`__repokid/init.py`:
+
         $ vim repokid/__init__.py
-        ``
+
 3. Create a package for your newest version:
-        ```
+
         $ python setup.py sdist
-        ```
+
 4. Upload to Pypi using Twine:
-        ```
-        twine upload dist/*
-        ```
+        
+        $ twine upload dist/*
+
 #### Problems that can be found when creating new versions.
 Pypi has a "known problem" with versions of the same title, for example, reuploading a failed attempt, or trying to patch over the top of a dist that has a file missing. This will result in a failure, and will require you to bump numbers again. As they are immutable, effectively. So version numbers can be used fairly liberally.
 
-### Context around using Twine:
+#### Context around using Twine:
 Please refer to the "Why Should I Use This" section:
 > https://github.com/pypa/twine
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,29 @@ If you're adding something to one of our modules that are already covered by uni
 
 Please also verify that the changes you've made work as expected locally.
 
+Pushing New Versions to Pypi
+----------------------------
+For the majority of contributors, this will not be a huge factor, however, for those deploying new versions, the instructions are as follows:
+1. Ensure you have `twine` installed, this is part of the requirements file, so if you've installed via the recommended paths, you should be fine..
+2. Edit the version number present in the __`__repokid/___init___.py`:
+        ```
+        $ vim repokid/__init__.py
+        ``
+3. Create a package for your newest version:
+        ```
+        $ python setup.py sdist
+        ```
+4. Upload to Pypi using Twine:
+        ```
+        twine upload dist/*
+        ```
+#### Problems that can be found when creating new versions.
+Pypi has a "known problem" with versions of the same title, for example, reuploading a failed attempt, or trying to patch over the top of a dist that has a file missing. This will result in a failure, and will require you to bump numbers again. As they are immutable, effectively. So version numbers can be used fairly liberally.
+
+### Context around using Twine:
+Please refer to the "Why Should I Use This" section:
+> https://github.com/pypa/twine
+
 Chat with our Developers
 ------------------------
 Our developers are in [Gitter](https://gitter.im/netflix-repokid/Lobby).  Whether you're seeing a bug, thinking about a new feature, or wondering about a design decision drop by and ask!

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.8'
+__version__ = '0.7.8.3'
 
 
 def init_config():

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.8.5'
+__version__ = '0.7.9'
 
 
 def init_config():

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.9'
+__version__ = '0.7.10'
 
 
 def init_config():

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.8.3'
+__version__ = '0.7.8.5'
 
 
 def init_config():

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,5 @@ requests
 tabulate
 tabview
 tqdm
+pip-tools
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,12 @@ boto==2.48.0              # via cloudaux
 botocore==1.8.39          # via boto3, cloudaux, s3transfer
 certifi==2018.1.18        # via requests
 chardet==3.0.4            # via requests
+click==6.7                # via pip-tools
 cloudaux==1.4.6
 defusedxml==0.5.0         # via cloudaux
 docopt==0.6.2
 docutils==0.14            # via botocore
+first==2.0.1              # via pip-tools
 flagpole==1.0.1           # via cloudaux
 futures==3.2.0            # via s3transfer
 idna==2.6                 # via requests
@@ -21,12 +23,16 @@ inflection==0.3.1         # via cloudaux
 jmespath==0.9.3           # via boto3, botocore
 joblib==0.11              # via cloudaux
 marshmallow==2.15.0
+pip-tools==1.11.0
+pkginfo==1.4.2            # via twine
 policyuniverse==1.1.0.1
 python-dateutil==2.6.1    # via botocore
+requests-toolbelt==0.8.0  # via twine
 requests==2.18.4
 s3transfer==0.1.12        # via boto3
-six==1.11.0               # via import-string, python-dateutil
+six==1.11.0               # via import-string, pip-tools, python-dateutil
 tabulate==0.8.2
 tabview==1.4.3
 tqdm==4.19.5
+twine==1.11.0
 urllib3==1.22             # via requests

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,28 @@ with open('repokid/__init__.py', 'rb') as f:
 setup(
     name='repokid',
     version=REPOKID_VERSION,
+    description=' AWS Least Privilege for Distributed, High-Velocity Deployment.',
     long_description=__doc__,
+    url='https://github.com/Netflix/repokid',
     packages=find_packages(),
     install_requires=REQUIRED,
+    keywords=['aws', 'iam', 'access_advisor'],
     entry_points={
         'console_scripts': [
             'repokid = repokid.cli.repokid_cli:main',
             'dispatcher = repokid.cli.dispatcher_cli:main'
         ],
-    }
+    },
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Security',
+        'Topic :: System',
+        'Topic :: System :: Systems Administration'
+        ]
 )

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,11 @@ with open('repokid/__init__.py', 'rb') as f:
 setup(
     name='repokid',
     version=REPOKID_VERSION,
-    description=' AWS Least Privilege for Distributed, High-Velocity Deployment.',
-    long_description=__doc__,
+    description='AWS Least Privilege for Distributed, High-Velocity Deployment',
+    # removed as I think getting long_desc to work is perhaps outside the scope
+    # of this PR, other long_desc's I've seen have used .rst to display on
+    # Pypi, so I think that may be necessary also.
+    # long_description=open("readme.md").read(),
     url='https://github.com/Netflix/repokid',
     packages=find_packages(),
     install_requires=REQUIRED,


### PR DESCRIPTION
Fix for Pip installations. Should be working as intended now, from what I understand after completing this task, it appeared the problem you were mainly facing was a lack of MANIFEST.in file, which is required to tell Pypi which files to include. This problem may also be causing the issue with long_description, but as explained inline, I felt that solving this problem now would distract from the PR itself and muddy it a bit. So that should be kept separate. End of the day, Pip install now works. That's what it's all about. 