### PR TITLE
Add repoable permissions count to stats

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.8'
+__version__ = '0.7.9'
 
 
 def init_config():

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -15,7 +15,7 @@ import json
 import logging.config
 import os
 
-__version__ = '0.7.9'
+__version__ = '0.7.11'
 
 
 def init_config():

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -961,12 +961,11 @@ def repo_stats(output_file, dynamo_table, account_number=None):
     rows = []
 
     for roleID in roleIDs:
-        role_data = get_role_data(dynamo_table, roleID, fields=['RoleId', 'RoleName', 'Account', 'Stats',
-                                                                'RepoablePermissions'])
+        role_data = get_role_data(dynamo_table, roleID, fields=['RoleId', 'RoleName', 'Account', 'Stats'])
         for stats_entry in role_data.get('Stats', []):
             rows.append([role_data['RoleId'], role_data['RoleName'], role_data['Account'], stats_entry['Date'],
-                         stats_entry['Source'], stats_entry['PermissionsCount'], role_data['RepoablePermissions'],
-                         stats_entry.get('DisqualifiedBy', [])])
+                         stats_entry['Source'], stats_entry['PermissionsCount'],
+                         stats_entry.get('RepoablePermissionsCount'), stats_entry.get('DisqualifiedBy', [])])
 
     try:
         with open(output_file, 'wb') as csvfile:

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -956,14 +956,16 @@ def repo_stats(output_file, dynamo_table, account_number=None):
     """
     roleIDs = (role_ids_for_account(dynamo_table, account_number) if account_number else
                role_ids_for_all_accounts(dynamo_table))
-    headers = ['RoleId', 'Role Name', 'Account', 'Date', 'Source', 'Permissions Count', 'Disqualified By']
+    headers = ['RoleId', 'Role Name', 'Account', 'Date', 'Source', 'Permissions Count', 'Repoable Permissions Count',
+               'Disqualified By']
     rows = []
 
     for roleID in roleIDs:
-        role_data = get_role_data(dynamo_table, roleID, fields=['RoleId', 'RoleName', 'Account', 'Stats'])
+        role_data = get_role_data(dynamo_table, roleID, fields=['RoleId', 'RoleName', 'Account', 'Stats',
+                                                                'RepoablePermissions'])
         for stats_entry in role_data.get('Stats', []):
             rows.append([role_data['RoleId'], role_data['RoleName'], role_data['Account'], stats_entry['Date'],
-                         stats_entry['Source'], stats_entry['PermissionsCount'],
+                         stats_entry['Source'], stats_entry['PermissionsCount'], role_data['RepoablePermissions'],
                          stats_entry.get('DisqualifiedBy', [])])
 
     try:

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -222,7 +222,7 @@ def update_stats(dynamo_table, roles, source='Scan'):
             cur_stats = {'DisqualifiedBy': [], 'PermissionsCount': 0, 'RepoablePermissionsCount': 0}
 
         for item in ['DisqualifiedBy', 'PermissionsCount', 'RepoablePermissionsCount']:
-            if new_stats[item] != cur_stats[item]:
+            if new_stats.get(item) != cur_stats.get(item):
                 add_to_end_of_list(dynamo_table, role.role_id, 'Stats', new_stats)
 
 

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -219,9 +219,9 @@ def update_stats(dynamo_table, roles, source='Scan'):
         try:
             cur_stats = role.stats[-1]
         except IndexError:
-            cur_stats = {'DisqualifiedBy': [], 'PermissionsCount': 0}
+            cur_stats = {'DisqualifiedBy': [], 'PermissionsCount': 0, 'RepoablePermissionsCount': 0}
 
-        for item in ['DisqualifiedBy', 'PermissionsCount']:
+        for item in ['DisqualifiedBy', 'PermissionsCount', 'RepoablePermissionsCount']:
             if new_stats[item] != cur_stats[item]:
                 add_to_end_of_list(dynamo_table, role.role_id, 'Stats', new_stats)
 

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -214,6 +214,7 @@ def update_stats(dynamo_table, roles, source='Scan'):
         new_stats = {'Date': datetime.datetime.utcnow().isoformat(),
                      'DisqualifiedBy': role.disqualified_by,
                      'PermissionsCount': role.total_permissions,
+                     'RepoablePermissionsCount': role.repoable_permissions,
                      'Source': source}
         try:
             cur_stats = role.stats[-1]


### PR DESCRIPTION
Hello Repokid developers 👋,
I'm sending this PR to write the repoable permissions count in the `repo_stats` command output as I find this information quite useful to track in our daily stats runs, I hope you'll find this useful as well 🙂

Cheers,
Marco

PS: repokid rocks! thanks for open sourcing it