### PR TITLE
Do not reschedule already scheduled roles

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -19,7 +19,7 @@ import os
 
 import import_string
 
-__version__ = '0.7.13'
+__version__ = '0.7.15'
 
 
 def init_config():

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -592,7 +592,7 @@ def schedule_repo(account_number, dynamo_table, config, hooks):
 
     scheduled_time = int(time.time()) + (86400 * config.get('repo_schedule_period_days', 7))
     for role in roles:
-        if role.repoable_permissions > 0:
+        if role.repoable_permissions > 0 and not role.repo_scheduled:
             role.repo_scheduled = scheduled_time
             set_role_data(dynamo_table, role.role_id, {'RepoScheduled': scheduled_time})
             scheduled_roles.append(role)


### PR DESCRIPTION
My current workflow is, for each day:
 - `update_role_cache`
 - `schedule_repo`
 - `repo_scheduled_roles -c`

I'm using the default 7 days grace period for scheduled roles. While running `show_scheduled_roles` I noticed that the Scheduled time entry was getting updated after each run of schedule_repo, thus postponing the repoing every day.

This PR introduces an extra check that does not update the Scheduled entry if already set.