### PR TITLE
Lookup repokid_roles table instead of using ResourceInUseException

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Repokid needs an IAM Role in each account that will be queried.  Additionally, R
 RepokidInstanceProfile:
 - Only create one.
 - Needs the ability to call `sts:AssumeRole` into all of the RepokidRoles.
-- DyamoDB permissions for the `repokid_roles` table and all indexes (specified in `assume_role` subsection of `dynamo_db` in config) and the ability to list its account tables with `dynamodb:ListTables`
+- DyamoDB permissions for the `repokid_roles` table and all indexes (specified in `assume_role` subsection of `dynamo_db` in config) and the ability to run `dynamodb:ListTables`
 
 RepokidRole:
 - Must exist in every account to be managed by repokid.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Repokid needs an IAM Role in each account that will be queried.  Additionally, R
 RepokidInstanceProfile:
 - Only create one.
 - Needs the ability to call `sts:AssumeRole` into all of the RepokidRoles.
-- DyamoDB permissions for the `repokid_roles` table and all indexes (specified in `assume_role` subsection of `dynamo_db` in config)
+- DyamoDB permissions for the `repokid_roles` table and all indexes (specified in `assume_role` subsection of `dynamo_db` in config) and the ability to list its account tables with `dynamodb:ListTables`
 
 RepokidRole:
 - Must exist in every account to be managed by repokid.

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -19,7 +19,7 @@ import os
 
 import import_string
 
-__version__ = '0.7.15'
+__version__ = '0.7.16'
 
 
 def init_config():

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -49,7 +49,6 @@ def dynamo_get_or_create_table(**dynamo_config):
     Returns:
         dynamo_table object
     """
-    table = None
     if 'localhost' in dynamo_config['endpoint']:
         resource = boto3.resource('dynamodb',
                                   region_name='us-east-1',
@@ -63,6 +62,11 @@ def dynamo_get_or_create_table(**dynamo_config):
             session_name=dynamo_config['session_name'],
             region=dynamo_config['region'])
 
+    for table in resource.tables.all():
+        if table.name == 'repokid_roles':
+            return table
+
+    table = None
     try:
         table = resource.create_table(
             TableName='repokid_roles',
@@ -121,10 +125,7 @@ def dynamo_get_or_create_table(**dynamo_config):
                 }])
 
     except BotoClientError as e:
-        if "ResourceInUseException" in e.message:
-            table = resource.Table('repokid_roles')
-        else:
-            LOGGER.error(e)
+        LOGGER.error(e)
     return table
 
 


### PR DESCRIPTION
This PR uses `resource.tables.all()` to lookup Repokid DynamoDB table instead of attempting to create such table every time and catch `ResourceInUseException` if it's already there.

Adds `dynamodb:ListTables` as requirement for RepokidInstanceProfile. Is it OK?