### PR TITLE
Track scheduled repo permissions

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -19,7 +19,7 @@ import os
 
 import import_string
 
-__version__ = '0.8.1'
+__version__ = '0.9.0'
 
 
 def init_config():

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -25,11 +25,12 @@ dict_to_attr = {'AAData': {'attribute': 'aa_data', 'default': dict()},
                 'Policies': {'attribute': 'policies', 'default': list()},
                 'Refreshed': {'attribute': 'refreshed', 'default': str()},
                 'RepoablePermissions': {'attribute': 'repoable_permissions', 'default': int()},
-                'RepoableServices': {'attribute': 'repoable_services', 'default': int()},
+                'RepoableServices': {'attribute': 'repoable_services', 'default': list()},
                 'Repoed': {'attribute': 'repoed', 'default': str()},
                 'RepoScheduled': {'attribute': 'repo_scheduled', 'default': int()},
                 'RoleId': {'attribute': 'role_id', 'default': None},
                 'RoleName': {'attribute': 'role_name', 'default': None},
+                'ScheduledPerms': {'attribute': 'scheduled_perms', 'default': dict()},
                 'Stats': {'attribute': 'stats', 'default': list()},
                 'TotalPermissions': {'attribute': 'total_permissions', 'default': int()}}
 

--- a/repokid/tests/test_roledata.py
+++ b/repokid/tests/test_roledata.py
@@ -166,3 +166,11 @@ class TestRoledata(object):
         assert repokid.utils.roledata._convert_repoed_service_to_sorted_perms_and_services(repoed_services) == (
             expected_permissions, expected_services
         )
+
+    def test_filter_scheduled_repoable_perms(self):
+        assert repokid.utils.roledata._filter_scheduled_repoable_perms(
+            ['a:b', 'a:c', 'b:a'], ['a:c', 'b']) == ['a:c', 'b:a']
+        assert repokid.utils.roledata._filter_scheduled_repoable_perms(
+            ['a:b', 'a:c', 'b:a'], ['a', 'b']) == ['a:b', 'a:c', 'b:a']
+        assert repokid.utils.roledata._filter_scheduled_repoable_perms(
+            ['a:b', 'a:c', 'b:a'], ['a:b', 'a:c']) == ['a:b', 'a:c']

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -334,6 +334,21 @@ def _convert_repoed_service_to_sorted_perms_and_services(repoed_services):
     return (sorted(repoable_permissions), sorted(repoable_services))
 
 
+def _filter_scheduled_repoable_perms(repoable_permissions, scheduled_perms):
+    """
+    Take a list of current repoable permissions and filter out any that weren't in the list of scheduled permissions
+
+    Args:
+        repoable_permissions (list): List of expanded permissions that are currently believed repoable
+        scheduled_permissions (list): List of scheduled permissions and services (stored in Dynamo at schedule time)
+    Returns:
+        list: New (filtered) repoable permissions
+    """
+    (scheduled_permissions, scheduled_services) = _convert_repoed_service_to_sorted_perms_and_services(scheduled_perms)
+    return([perm for perm in repoable_permissions
+           if(perm in scheduled_permissions or perm.split(':')[0] in scheduled_services)])
+
+
 def _get_repoable_permissions(account_number, role_name, permissions, aa_data, no_repo_permissions, minimum_age,
                               hooks):
     """


### PR DESCRIPTION
This commit changes scheduled repoing to track which permissions
were scheduled. This is needed because we only want to take away
permissions we have told the developers about.

With this change, if you schedule a repo it will keep an entry in
Dynamo with the current repoable permissions and services.

Repoing these scheduled roles will only remove permissions that
are in this scheduled set.

This commit also adds the ability to cancel a scheduled repo
for every role in the account.