### PR TITLE
Adding a hook for before repo roles

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -19,7 +19,7 @@ import os
 
 import import_string
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 
 def init_config():

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -972,6 +972,8 @@ def repo_all_roles(account_number, dynamo_table, config, hooks, commit=False, sc
                                                                       account_number,
                                                                       ', '.join([role.role_name for role in roles])))
 
+    repokid.hooks.call_hooks(hooks, 'BEFORE_REPO_ROLES', {'account_number': account_number, 'roles': roles})
+
     for role in roles:
         error = repo_role(account_number, role.role_name, dynamo_table, config, hooks, commit=commit,
                           scheduled=scheduled)

--- a/repokid/hooks/loggers/__init__.py
+++ b/repokid/hooks/loggers/__init__.py
@@ -2,6 +2,14 @@ from repokid import LOGGER
 import repokid.hooks as hooks
 
 
+@hooks.implements_hook('BEFORE_REPO_ROLES', 1)
+def log_before_repo_roles(input_dict):
+    LOGGER.debug("Calling DURING_REPOABLE_CALCULATION hooks")
+    if not all(required in input_dict for required in ['account_number', 'roles']):
+        raise hooks.MissingHookParamaeter("Did not get all required parameters for BEFORE_REPO_ROLES hook")
+    return input_dict
+
+
 @hooks.implements_hook('DURING_REPOABLE_CALCULATION', 1)
 def log_during_repoable_calculation_hooks(input_dict):
     LOGGER.debug("Calling DURING_REPOABLE_CALCULATION hooks")


### PR DESCRIPTION
This commit adds a hook that fires before repoing all roles
(scheduled or not). This gives the chance to do filtering based
on account number or roles in the list.