### PR TITLE
Fixes to scheduled roles

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -19,7 +19,7 @@ import os
 
 import import_string
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 
 
 def init_config():


### PR DESCRIPTION
This commit removes roles that show as scheduled when they should
not by:

1) Only showing active roles in show_scheduled_roles
2) If repoing encounters a problem, unschedule the role