### PR TITLE
UPDATE - clean readme, add makefile automation and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-*.json
+config.json
 *.log
 *.csv
 build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Environmental Variables
+PACKAGES=aws
+
+# check_host_system_installs:
+# Runs `which` against program targets to ensure that the users development
+# environment contains all the necessary packages.
+#
+# Environmental Variables:
+# 	PACKAGES: A space separated list of packages required in the users
+# 			  environment.
+check_host_system_installs:
+	for package in $(PACKAGES); do \
+		which $$package ; \
+	done
+
+# check_aws_region:
+# Retrieves the default AWS region present in your environment.
+check_aws_region:
+	aws configure get default.region

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ $ repokid find_roles_with_permissions "s3:putobjectacl" "sts:assumerole" --outpu
 ...
 $ repokid remove_permissions_from_roles --role-file=myroles.json "s3:putobjectacl" "sts:assumerole" -c
 ```
+### Makefile rules
+
+The Makefile at the root of the directory contains some commands that can be used to manage the repository and perform some useful actions that may assist operators/developers.
+
+| command | description |
+| ------- | ----------- |
+| check_host_system_installs | Runs `which` against `binary` targets to check the host level |
+| check_aws_region | Runs an `aws` command that checks the default region set in the local environment. |
 
 ### Rolling back
 Repokid stores a copy of each version of inline policies it knows about.  These are added when


### PR DESCRIPTION
Updates to README. General cleaning. Added a Makefile to start some repository automation and then also updated the gitignore.

Let me know if you want this to be rebased.

```
The following changes since commit a7db1037063b148b6481ee203e9f3c86f6edc443:

  Removing references to whitelist/blacklist. (#215) (2019-03-28 16:22:55 -0700)

are available in the Git repository at:

  git@github.com:JohnVonNeumann/repokid.git add-script-to-provision-base-dynamodb

for you to fetch changes up to e9e8691aaa4d64588a3fd4b779944d384ddc27f9:

  CREATE Makefile - add two new rules: (2019-08-29 17:45:36 +1000)

----------------------------------------------------------------
JohnVonNeumann (3):
      UPDATE gitignore - dont blanket ignore json files, only ignore config.json
      UPDATE README - add content around makefiles
      CREATE Makefile - add two new rules:

 .gitignore |  2 +-
 Makefile   | 19 +++++++++++++++++++
 README.md  |  8 ++++++++
 3 files changed, 28 insertions(+), 1 deletion(-)
 create mode 100644 Makefile

diff --git a/.gitignore b/.gitignore
index e9fff7d..aefc77f 100644
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-*.json
+config.json
 *.log
 *.csv
 build
diff --git a/Makefile b/Makefile
new file mode 100644
index 0000000..586afc0
--- /dev/null
+++ b/Makefile
@@ -0,0 +1,19 @@
+# Environmental Variables
+PACKAGES=aws
+
+# check_host_system_installs:
+# Runs `which` against program targets to ensure that the users development
+# environment contains all the necessary packages.
+#
+# Environmental Variables:
+#      PACKAGES: A space separated list of packages required in the users
+#                        environment.
+check_host_system_installs:
+       for package in $(PACKAGES); do \
+               which $$package ; \
+       done
+
+# check_aws_region:
+# Retrieves the default AWS region present in your environment.
+check_aws_region:
+       aws configure get default.region
diff --git a/README.md b/README.md
index abf9f5a..b2eb253 100644
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ $ repokid find_roles_with_permissions "s3:putobjectacl" "sts:assumerole" --outpu
 ...
 $ repokid remove_permissions_from_roles --role-file=myroles.json "s3:putobjectacl" "sts:assumerole" -c

+### Makefile rules
+
+The Makefile at the root of the directory contains some commands that can be used to manage the repository and perform some useful actions that may assist operators/developers.
+
+| command | description |
+| ------- | ----------- |
+| check_host_system_installs | Runs `which` against `binary` targets to check the host level |
+| check_aws_region | Runs an `aws` command that checks the default region set in the local environment. |

```