### PR TITLE
Update repokid_cli.py

### DIFF
--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -608,7 +608,7 @@ def find_roles_with_permissions(permissions, dynamo_table, output_file):
     if not output_file:
         return
 
-    with open(output_file, "wb") as fd:
+    with open(output_file, "w") as fd:
         json.dump(arns, fd)
 
     LOGGER.info('Ouput written to file "{output_file}"'.format(output_file=output_file))


### PR DESCRIPTION
Modified writter parameter.
	Fixes the error for writing to file with command "find_roles_with_permissions --output".