### PR TITLE
Assign LOGGER instead of importing

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -20,7 +20,7 @@ import os
 
 import import_string
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 
 def init_config():

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -37,13 +37,12 @@ Options:
 
 import json
 import sys
+import logging
 
 from docopt import docopt
 from repokid import __version__ as __version__
 from repokid import CONFIG
 from repokid import get_hooks
-import logging
-LOGGER = logging.getLogger("repokid")
 from repokid.commands.repo import repo_all_roles, repo_role, repo_stats, rollback_role
 from repokid.commands.role import (
     display_role,
@@ -61,6 +60,8 @@ from repokid.utils.dynamo import dynamo_get_or_create_table
 
 
 # http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html
+
+LOGGER = logging.getLogger("repokid")
 
 
 def _generate_default_config(filename=None):

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -42,7 +42,8 @@ from docopt import docopt
 from repokid import __version__ as __version__
 from repokid import CONFIG
 from repokid import get_hooks
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 from repokid.commands.repo import repo_all_roles, repo_role, repo_stats, rollback_role
 from repokid.commands.role import (
     display_role,

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -36,8 +36,8 @@ Options:
 """
 
 import json
-import sys
 import logging
+import sys
 
 from docopt import docopt
 from repokid import __version__ as __version__

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -23,7 +23,8 @@ from cloudaux.aws.iam import (
     get_role_inline_policies,
     put_role_policy,
 )
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role, Roles
 from repokid.utils import roledata as roledata

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -14,8 +14,8 @@
 import csv
 import datetime
 import json
-import pprint
 import logging
+import pprint
 import time
 
 import botocore

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -15,8 +15,8 @@ import csv
 import datetime
 import json
 import pprint
-import time
 import logging
+import time
 
 import botocore
 from cloudaux.aws.iam import (

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -16,6 +16,7 @@ import datetime
 import json
 import pprint
 import time
+import logging
 
 import botocore
 from cloudaux.aws.iam import (
@@ -23,8 +24,6 @@ from cloudaux.aws.iam import (
     get_role_inline_policies,
     put_role_policy,
 )
-import logging
-LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role, Roles
 from repokid.utils import roledata as roledata
@@ -44,6 +43,8 @@ from repokid.utils.iam import (
 from repokid.utils.logging import log_deleted_and_repoed_policies
 from repokid.utils.roledata import partial_update_role_data
 from tabulate import tabulate
+
+LOGGER = logging.getLogger("repokid")
 
 
 def repo_role(

--- a/repokid/commands/role.py
+++ b/repokid/commands/role.py
@@ -15,7 +15,8 @@ import csv
 import json
 
 from policyuniverse.arn import ARN
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role, Roles
 from repokid.utils import roledata as roledata

--- a/repokid/commands/role.py
+++ b/repokid/commands/role.py
@@ -13,10 +13,9 @@
 #     limitations under the License.
 import csv
 import json
+import logging
 
 from policyuniverse.arn import ARN
-import logging
-LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role, Roles
 from repokid.utils import roledata as roledata
@@ -33,6 +32,8 @@ from repokid.utils.iam import (
 from tabulate import tabulate
 import tabview as t
 from tqdm import tqdm
+
+LOGGER = logging.getLogger("repokid")
 
 
 def display_roles(account_number, dynamo_table, inactive=False):

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -11,15 +11,17 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-from cloudaux.aws.iam import get_account_authorization_details
 import logging
-LOGGER = logging.getLogger("repokid")
+
+from cloudaux.aws.iam import get_account_authorization_details
 from repokid.filters import FilterPlugins
 from repokid.role import Role, Roles
 from repokid.utils import roledata as roledata
 from repokid.utils.aardvark import get_aardvark_data
 from repokid.utils.dynamo import set_role_data
 from tqdm import tqdm
+
+LOGGER = logging.getLogger("repokid")
 
 
 def update_role_cache(account_number, dynamo_table, config, hooks):

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -12,7 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 from cloudaux.aws.iam import get_account_authorization_details
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 from repokid.filters import FilterPlugins
 from repokid.role import Role, Roles
 from repokid.utils import roledata as roledata

--- a/repokid/commands/schedule.py
+++ b/repokid/commands/schedule.py
@@ -14,7 +14,8 @@
 from datetime import datetime as dt
 import time
 
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role, Roles
 from repokid.utils.dynamo import (

--- a/repokid/commands/schedule.py
+++ b/repokid/commands/schedule.py
@@ -12,8 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 from datetime import datetime as dt
-import time
 import logging
+import time
 
 import repokid.hooks
 from repokid.role import Role, Roles

--- a/repokid/commands/schedule.py
+++ b/repokid/commands/schedule.py
@@ -13,9 +13,8 @@
 #     limitations under the License.
 from datetime import datetime as dt
 import time
-
 import logging
-LOGGER = logging.getLogger("repokid")
+
 import repokid.hooks
 from repokid.role import Role, Roles
 from repokid.utils.dynamo import (
@@ -26,6 +25,8 @@ from repokid.utils.dynamo import (
 )
 from tabulate import tabulate
 from tqdm import tqdm
+
+LOGGER = logging.getLogger("repokid")
 
 
 def schedule_repo(account_number, dynamo_table, config, hooks):

--- a/repokid/filters/__init__.py
+++ b/repokid/filters/__init__.py
@@ -1,5 +1,6 @@
 import import_string
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 
 
 # inspiration from https://github.com/slackhq/python-rtmbot/blob/master/rtmbot/core.py

--- a/repokid/filters/__init__.py
+++ b/repokid/filters/__init__.py
@@ -1,5 +1,6 @@
 import import_string
 import logging
+
 LOGGER = logging.getLogger("repokid")
 
 

--- a/repokid/filters/__init__.py
+++ b/repokid/filters/__init__.py
@@ -1,5 +1,6 @@
-import import_string
 import logging
+
+import import_string
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/filters/age/__init__.py
+++ b/repokid/filters/age/__init__.py
@@ -1,7 +1,7 @@
 import datetime
 
 from dateutil.tz import tzlocal
-from repokid import LOGGER
+LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
 
 

--- a/repokid/filters/age/__init__.py
+++ b/repokid/filters/age/__init__.py
@@ -1,9 +1,10 @@
 import datetime
+import logging
 
 from dateutil.tz import tzlocal
-import logging
-LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
+
+LOGGER = logging.getLogger("repokid")
 
 
 class AgeFilter(Filter):

--- a/repokid/filters/age/__init__.py
+++ b/repokid/filters/age/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 
 from dateutil.tz import tzlocal
+import logging
 LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
 

--- a/repokid/filters/blocklist/__init__.py
+++ b/repokid/filters/blocklist/__init__.py
@@ -3,6 +3,7 @@ import sys
 
 import botocore
 from cloudaux.aws.sts import boto3_cached_conn
+import logging
 LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
 

--- a/repokid/filters/blocklist/__init__.py
+++ b/repokid/filters/blocklist/__init__.py
@@ -1,11 +1,12 @@
 import json
 import sys
+import logging
 
 import botocore
 from cloudaux.aws.sts import boto3_cached_conn
-import logging
-LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
+
+LOGGER = logging.getLogger("repokid")
 
 
 def get_blocklist_from_bucket(bucket_config):

--- a/repokid/filters/blocklist/__init__.py
+++ b/repokid/filters/blocklist/__init__.py
@@ -1,6 +1,6 @@
 import json
-import sys
 import logging
+import sys
 
 import botocore
 from cloudaux.aws.sts import boto3_cached_conn

--- a/repokid/filters/blocklist/__init__.py
+++ b/repokid/filters/blocklist/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 import botocore
 from cloudaux.aws.sts import boto3_cached_conn
-from repokid import LOGGER
+LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
 
 

--- a/repokid/filters/exclusive/__init__.py
+++ b/repokid/filters/exclusive/__init__.py
@@ -1,8 +1,9 @@
 import fnmatch
-
 import logging
-LOGGER = logging.getLogger("repokid")
+
 from repokid.filters import Filter
+
+LOGGER = logging.getLogger("repokid")
 
 
 class ExclusiveFilter(Filter):

--- a/repokid/filters/exclusive/__init__.py
+++ b/repokid/filters/exclusive/__init__.py
@@ -1,6 +1,6 @@
 import fnmatch
 
-from repokid import LOGGER
+LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
 
 

--- a/repokid/filters/exclusive/__init__.py
+++ b/repokid/filters/exclusive/__init__.py
@@ -1,5 +1,6 @@
 import fnmatch
 
+import logging
 LOGGER = logging.getLogger("repokid")
 from repokid.filters import Filter
 

--- a/repokid/hooks/loggers/__init__.py
+++ b/repokid/hooks/loggers/__init__.py
@@ -1,4 +1,5 @@
 import logging
+
 import repokid.hooks as hooks
 from repokid.role import Role
 

--- a/repokid/hooks/loggers/__init__.py
+++ b/repokid/hooks/loggers/__init__.py
@@ -1,4 +1,4 @@
-from repokid import LOGGER
+LOGGER = logging.getLogger("repokid")
 import repokid.hooks as hooks
 from repokid.role import Role
 

--- a/repokid/hooks/loggers/__init__.py
+++ b/repokid/hooks/loggers/__init__.py
@@ -1,3 +1,4 @@
+import logging
 LOGGER = logging.getLogger("repokid")
 import repokid.hooks as hooks
 from repokid.role import Role

--- a/repokid/hooks/loggers/__init__.py
+++ b/repokid/hooks/loggers/__init__.py
@@ -1,7 +1,8 @@
 import logging
-LOGGER = logging.getLogger("repokid")
 import repokid.hooks as hooks
 from repokid.role import Role
+
+LOGGER = logging.getLogger("repokid")
 
 
 @hooks.implements_hook("BEFORE_REPO_ROLES", 1)

--- a/repokid/utils/aardvark.py
+++ b/repokid/utils/aardvark.py
@@ -11,8 +11,9 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-import sys
 import logging
+import sys
+
 import requests
 
 LOGGER = logging.getLogger("repokid")

--- a/repokid/utils/aardvark.py
+++ b/repokid/utils/aardvark.py
@@ -12,10 +12,10 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 import sys
-
 import logging
-LOGGER = logging.getLogger("repokid")
 import requests
+
+LOGGER = logging.getLogger("repokid")
 
 
 def get_aardvark_data(aardvark_api_location, account_number=None, arn=None):

--- a/repokid/utils/aardvark.py
+++ b/repokid/utils/aardvark.py
@@ -13,7 +13,8 @@
 #     limitations under the License.
 import sys
 
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 import requests
 
 

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
-import sys
 import logging
+import sys
 
 import boto3
 from botocore.exceptions import ClientError as BotoClientError

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -5,7 +5,8 @@ import sys
 import boto3
 from botocore.exceptions import ClientError as BotoClientError
 from cloudaux.aws.sts import boto3_cached_conn as boto3_cached_conn
-from repokid import LOGGER as LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 
 # used as a placeholder for empty SID to work around this: https://github.com/aws/aws-sdk-js/issues/833
 DYNAMO_EMPTY_STRING = "---DYNAMO-EMPTY-STRING---"

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -1,13 +1,13 @@
 import copy
 import datetime
 import sys
+import logging
 
 import boto3
 from botocore.exceptions import ClientError as BotoClientError
 from cloudaux.aws.sts import boto3_cached_conn as boto3_cached_conn
-import logging
-LOGGER = logging.getLogger("repokid")
 
+LOGGER = logging.getLogger("repokid")
 # used as a placeholder for empty SID to work around this: https://github.com/aws/aws-sdk-js/issues/833
 DYNAMO_EMPTY_STRING = "---DYNAMO-EMPTY-STRING---"
 

--- a/repokid/utils/iam.py
+++ b/repokid/utils/iam.py
@@ -14,6 +14,7 @@
 import datetime
 import json
 import re
+import logging
 
 import botocore
 from cloudaux import sts_conn
@@ -22,13 +23,12 @@ from cloudaux.aws.iam import (
     get_role_inline_policies,
     put_role_policy,
 )
-import logging
-LOGGER = logging.getLogger("repokid")
 from repokid.utils import roledata as roledata
 from repokid.utils.dynamo import set_role_data
 from repokid.utils.logging import log_deleted_and_repoed_policies
 from repokid.utils.roledata import partial_update_role_data
 
+LOGGER = logging.getLogger("repokid")
 MAX_AWS_POLICY_SIZE = 10240
 
 

--- a/repokid/utils/iam.py
+++ b/repokid/utils/iam.py
@@ -22,7 +22,8 @@ from cloudaux.aws.iam import (
     get_role_inline_policies,
     put_role_policy,
 )
-from repokid import LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 from repokid.utils import roledata as roledata
 from repokid.utils.dynamo import set_role_data
 from repokid.utils.logging import log_deleted_and_repoed_policies

--- a/repokid/utils/iam.py
+++ b/repokid/utils/iam.py
@@ -13,8 +13,8 @@
 #     limitations under the License.
 import datetime
 import json
-import re
 import logging
+import re
 
 import botocore
 from cloudaux import sts_conn

--- a/repokid/utils/logging.py
+++ b/repokid/utils/logging.py
@@ -14,8 +14,8 @@
 from datetime import datetime
 import json
 from socket import gethostname
-import traceback
 import logging
+import traceback
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/utils/logging.py
+++ b/repokid/utils/logging.py
@@ -13,11 +13,10 @@
 #     limitations under the License.
 from datetime import datetime
 import json
-import logging
 from socket import gethostname
 import traceback
-
 import logging
+
 LOGGER = logging.getLogger("repokid")
 
 

--- a/repokid/utils/logging.py
+++ b/repokid/utils/logging.py
@@ -17,7 +17,7 @@ import logging
 from socket import gethostname
 import traceback
 
-from repokid import LOGGER
+LOGGER = logging.getLogger("repokid")
 
 
 class JSONFormatter(logging.Formatter):

--- a/repokid/utils/logging.py
+++ b/repokid/utils/logging.py
@@ -13,8 +13,8 @@
 #     limitations under the License.
 from datetime import datetime
 import json
-from socket import gethostname
 import logging
+from socket import gethostname
 import traceback
 
 LOGGER = logging.getLogger("repokid")

--- a/repokid/utils/logging.py
+++ b/repokid/utils/logging.py
@@ -17,6 +17,7 @@ import logging
 from socket import gethostname
 import traceback
 
+import logging
 LOGGER = logging.getLogger("repokid")
 
 

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -20,7 +20,8 @@ from cloudaux.aws.iam import get_role_inline_policies
 from dateutil.tz import tzlocal
 from policyuniverse import all_permissions, expand_policy, get_actions_from_statement
 from repokid import CONFIG as CONFIG
-from repokid import LOGGER as LOGGER
+import logging
+LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role
 from repokid.utils.aardvark import get_aardvark_data

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -14,8 +14,8 @@
 from collections import defaultdict
 import copy
 import datetime
-import time
 import logging
+import time
 
 from cloudaux.aws.iam import get_role_inline_policies
 from dateutil.tz import tzlocal

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -15,13 +15,12 @@ from collections import defaultdict
 import copy
 import datetime
 import time
+import logging
 
 from cloudaux.aws.iam import get_role_inline_policies
 from dateutil.tz import tzlocal
 from policyuniverse import all_permissions, expand_policy, get_actions_from_statement
 from repokid import CONFIG as CONFIG
-import logging
-LOGGER = logging.getLogger("repokid")
 import repokid.hooks
 from repokid.role import Role
 from repokid.utils.aardvark import get_aardvark_data
@@ -33,6 +32,7 @@ from repokid.utils.dynamo import (
     store_initial_role_data,
 )
 
+LOGGER = logging.getLogger("repokid")
 BEGINNING_OF_2015_MILLI_EPOCH = 1420113600000
 IAM_ACCESS_ADVISOR_UNSUPPORTED_SERVICES = frozenset([""])
 IAM_ACCESS_ADVISOR_UNSUPPORTED_ACTIONS = frozenset(["iam:passrole"])


### PR DESCRIPTION
LOGGER was being imported from repokid module but it was not able to
find the module variable.

As a quick workaround I assigned (per Patrick Sanders' recommendation)
LOGGER directly to logging.getLogger("repokid") and import logging
module where needed.