### PR TITLE
Don't exit on errors, only fetch blocklist once

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -20,7 +20,7 @@ import os
 
 import import_string
 
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 
 
 def init_config():

--- a/repokid/exceptions/__init__.py
+++ b/repokid/exceptions/__init__.py
@@ -1,2 +1,10 @@
 class UnexpectedDynamoUpdateValue(Exception):
     pass
+
+
+class BlocklistError(Exception):
+    pass
+
+
+class AardvarkError(Exception):
+    pass

--- a/repokid/filters/blocklist/__init__.py
+++ b/repokid/filters/blocklist/__init__.py
@@ -1,9 +1,9 @@
 import json
 import logging
-import sys
 
 import botocore
 from cloudaux.aws.sts import boto3_cached_conn
+from repokid.exceptions import BlocklistError
 from repokid.filters import Filter
 
 LOGGER = logging.getLogger("repokid")
@@ -27,30 +27,26 @@ def get_blocklist_from_bucket(bucket_config):
         blocklist_json = json.loads(blocklist)
     # Blocklist problems are really bad and we should quit rather than silently continue
     except (botocore.exceptions.ClientError, AttributeError):
-        LOGGER.error(
+        LOGGER.critical(
             "S3 blocklist config was set but unable to connect retrieve object, quitting"
         )
-        sys.exit(1)
+        raise BlocklistError("Could not retrieve blocklist")
     except ValueError:
-        LOGGER.error(
+        LOGGER.critical(
             "S3 blocklist config was set but the returned file is bad, quitting"
         )
-        sys.exit(1)
-    if set(blocklist_json.keys()) != set(["arns", "names"]):
-        LOGGER.error("S3 blocklist file is malformed, quitting")
-        sys.exit(1)
+        raise BlocklistError("Could not parse blocklist")
+    if set(blocklist_json.keys()) != {"arns", "names"}:
+        LOGGER.critical("S3 blocklist file is malformed, quitting")
+        raise BlocklistError("Could not parse blocklist")
     return blocklist_json
 
 
 class BlocklistFilter(Filter):
-    def __init__(self, config=None):
-        blocklist_json = None
-        bucket_config = config.get(
-            "blocklist_bucket", config.get("blacklist_bucket", None)
-        )
-        if bucket_config:
-            blocklist_json = get_blocklist_from_bucket(bucket_config)
+    blocklist_json = None
 
+    def __init__(self, config=None):
+        super().__init__(config)
         current_account = config.get("current_account") or None
         if not current_account:
             LOGGER.error("Unable to get current account for Blocklist Filter")
@@ -63,19 +59,32 @@ class BlocklistFilter(Filter):
             [rolename.lower() for rolename in config.get("all", [])]
         )
 
-        if blocklist_json:
+        if BlocklistFilter.blocklist_json:
             blocklisted_role_names.update(
                 [
                     name.lower()
-                    for name, accounts in blocklist_json["names"].items()
+                    for name, accounts in BlocklistFilter.blocklist_json[
+                        "names"
+                    ].items()
                     if ("all" in accounts or config.get("current_account") in accounts)
                 ]
             )
 
         self.blocklisted_arns = (
-            set() if not blocklist_json else blocklist_json.get("arns", [])
+            set()
+            if not BlocklistFilter.blocklist_json
+            else BlocklistFilter.blocklist_json.get("arns", [])
         )
         self.blocklisted_role_names = blocklisted_role_names
+
+    @classmethod
+    def init_blocklist(cls, config):
+        if not cls.blocklist_json:
+            bucket_config = config.get(
+                "blocklist_bucket", config.get("blacklist_bucket", None)
+            )
+            if bucket_config:
+                cls.blocklist_json = get_blocklist_from_bucket(bucket_config)
 
     def apply(self, input_list):
         blocklisted_roles = []

--- a/repokid/utils/aardvark.py
+++ b/repokid/utils/aardvark.py
@@ -12,8 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 import logging
-import sys
 
+from repokid.exceptions import AardvarkError
 import requests
 
 LOGGER = logging.getLogger("repokid")
@@ -52,12 +52,12 @@ def get_aardvark_data(aardvark_api_location, account_number=None, arn=None):
                 aardvark_api_location, params=params, json=payload
             )
         except requests.exceptions.RequestException as e:
-            LOGGER.error("Unable to get Aardvark data: {}".format(e))
-            sys.exit(1)
+            LOGGER.exception("Unable to get Aardvark data: {}".format(e))
+            raise AardvarkError("Unable to get aardvark data")
         else:
             if r_aardvark.status_code != 200:
-                LOGGER.error("Unable to get Aardvark data")
-                sys.exit(1)
+                LOGGER.exception("Unable to get Aardvark data")
+                raise AardvarkError("Unable to get aardvark data")
 
             response_data.update(r_aardvark.json())
             # don't want these in our Aardvark data


### PR DESCRIPTION
This PR:
- replaces calls to `sys.exit()` with exceptions to be handled at higher levels
- makes the blocklist a class variable so it only needs to be fetched from S3 once per run