### PR TITLE
Add update flag to repo methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,4 @@
+- Repokid Maintainers <repokid-maintainers@netflix.com>
 - Patrick Kelley <pkelley@netflix.com>
 - Travis McPeak <tmcpeak@netflix.com>
+- Patrick Sanders <psanders@netflix.com>

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -20,7 +20,7 @@ import os
 
 import import_string
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"
 
 
 def init_config():

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -122,7 +122,8 @@ def _repo_role(
         LOGGER.error(
             "AAData older than threshold for these services: {} (role: {}, account {})".format(
                 old_aa_data_services, role_name, account_number
-            )
+            ),
+            exc_info=True,
         )
         continuing = False
 
@@ -319,7 +320,7 @@ def _rollback_role(
             message = "Unable to push policy {}.  Error: {} (role: {} account {})".format(
                 policy_name, e.message, role.role_name, account_number
             )
-            LOGGER.error(message)
+            LOGGER.error(message, exc_info=True)
             errors.append(message)
 
         else:
@@ -343,7 +344,7 @@ def _rollback_role(
                 message = "Unable to delete policy {}.  Error: {} (role: {} account {})".format(
                     policy_name, e.message, role.role_name, account_number
                 )
-                LOGGER.error(message)
+                LOGGER.error(message, exc_info=True)
                 errors.append(message)
 
     partial_update_role_data(
@@ -497,6 +498,8 @@ def _repo_stats(output_file, dynamo_table, account_number=None):
             for row in rows:
                 csv_writer.writerow(row)
     except IOError as e:
-        LOGGER.error("Unable to write file {}: {}".format(output_file, e))
+        LOGGER.error(
+            "Unable to write file {}: {}".format(output_file, e), exc_info=True
+        )
     else:
         LOGGER.info("Successfully wrote stats to {}".format(output_file))

--- a/repokid/lib/__init__.py
+++ b/repokid/lib/__init__.py
@@ -131,7 +131,9 @@ def display_role(account_number: str, role_name: str):
     return _display_role(account_number, role_name, dynamo_table, CONFIG, hooks)
 
 
-def repo_role(account_number: str, role_name: str, commit: bool = False):
+def repo_role(
+    account_number: str, role_name: str, commit: bool = False, update: bool = True
+):
     """
     Library wrapper to calculate what repoing can be done for a role and then actually do it if commit is set.
 
@@ -141,6 +143,7 @@ def repo_role(account_number: str, role_name: str, commit: bool = False):
         account_number (string): The current account number Repokid is being run against
         role_name (string)
         commit (bool)
+        update (bool)
 
     Returns:
         None
@@ -196,7 +199,7 @@ def schedule_repo(account_number: str):
     return _schedule_repo(account_number, dynamo_table, CONFIG, hooks)
 
 
-def repo_all_roles(account_number: str, commit: bool = False):
+def repo_all_roles(account_number: str, commit: bool = False, update: bool = True):
     """
     Convenience wrapper for repo_roles() with scheduled=False.
 
@@ -205,14 +208,17 @@ def repo_all_roles(account_number: str, commit: bool = False):
     Args:
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
+        update (bool): if True run update_role_cache before repoing
 
     Returns:
         None
     """
-    return repo_roles(account_number, commit=commit, scheduled=False)
+    return repo_roles(account_number, commit=commit, scheduled=False, update=update)
 
 
-def repo_scheduled_roles(account_number: str, commit: bool = False):
+def repo_scheduled_roles(
+    account_number: str, commit: bool = False, update: bool = True
+):
     """
     Convenience wrapper for repo_roles() with scheduled=True.
 
@@ -221,14 +227,20 @@ def repo_scheduled_roles(account_number: str, commit: bool = False):
     Args:
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
+        update (bool): if True run update_role_cache before repoing
 
     Returns:
         None
     """
-    return repo_roles(account_number, commit=commit, scheduled=True)
+    return repo_roles(account_number, commit=commit, scheduled=True, update=update)
 
 
-def repo_roles(account_number: str, commit: bool = False, scheduled: bool = False):
+def repo_roles(
+    account_number: str,
+    commit: bool = False,
+    scheduled: bool = False,
+    update: bool = True,
+):
     """
     Library wrapper to repo all scheduled or eligible roles in an account. Collect any errors and display them at the
     end.
@@ -239,11 +251,13 @@ def repo_roles(account_number: str, commit: bool = False, scheduled: bool = Fals
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
         scheduled (bool): if True only repo the scheduled roles, if False repo all the (eligible) roles
+        update (bool): if True run update_role_cache before repoing
 
     Returns:
         None
     """
-    _update_role_cache(account_number, dynamo_table, CONFIG, hooks)
+    if update:
+        _update_role_cache(account_number, dynamo_table, CONFIG, hooks)
     return _repo_all_roles(
         account_number, dynamo_table, CONFIG, hooks, commit=commit, scheduled=scheduled
     )

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -107,7 +107,7 @@ def dynamo_get_or_create_table(**dynamo_config):
         )
 
     except BotoClientError as e:
-        LOGGER.error(e)
+        LOGGER.error(e, exc_info=True)
     return table
 
 


### PR DESCRIPTION
Add `update` flag to allow library calls to skip the update_role_cache
call when repoing one or more roles with a default of `True`.