### PR TITLE
Add `limit` kwarg to repo functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Repokid is extensible via hooks that are called before, during, and after variou
 
 | Hook name | Context |
 |-----------|---------|
-| `AFTER_REPO` | role |
+| `AFTER_REPO` | role, errors |
+| `AFTER_REPO_ROLES` | roles, errors |
 | `BEFORE_REPO_ROLES` | account_number, roles |
 | `AFTER_SCHEDULE_REPO` | roles |
 | `DURING_REPOABLE_CALCULATION` | account_number, role_name, potentially_repoable_permissions, minimum_age |

--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -20,7 +20,7 @@ import os
 
 import import_string
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"
 
 
 def init_config():

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -378,7 +378,7 @@ def _repo_all_roles(
         config
         commit (bool): actually make the changes
         scheduled (bool): if True only repo the scheduled roles, if False repo all the (eligible) roles
-        limit (int): limit number of roles to be repoed per run (<0 is unlimited)
+        limit (int): limit number of roles to be repoed per run (< 0 is unlimited)
 
     Returns:
         None

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -367,7 +367,7 @@ def _rollback_role(
 
 
 def _repo_all_roles(
-    account_number, dynamo_table, config, hooks, commit=False, scheduled=True, limit=0
+    account_number, dynamo_table, config, hooks, commit=False, scheduled=True, limit=-1
 ):
     """
     Repo all scheduled or eligible roles in an account.  Collect any errors and display them at the end.
@@ -378,7 +378,7 @@ def _repo_all_roles(
         config
         commit (bool): actually make the changes
         scheduled (bool): if True only repo the scheduled roles, if False repo all the (eligible) roles
-        limit (int): limit number of roles to be repoed per run (0 is unlimited)
+        limit (int): limit number of roles to be repoed per run (<0 is unlimited)
 
     Returns:
         None
@@ -424,6 +424,8 @@ def _repo_all_roles(
     count = 0
     repoed = Roles([])
     for role in roles:
+        if limit >= 0 and count == limit:
+            break
         error = _repo_role(
             account_number,
             role.role_name,
@@ -437,8 +439,6 @@ def _repo_all_roles(
             errors.append(error)
         repoed.append(role)
         count += 1
-        if limit and count == limit:
-            break
 
     if errors:
         LOGGER.error(f"Error(s) during repo: \n{errors} (account: {account_number})")

--- a/repokid/lib/__init__.py
+++ b/repokid/lib/__init__.py
@@ -196,7 +196,7 @@ def schedule_repo(account_number: str):
     return _schedule_repo(account_number, dynamo_table, CONFIG, hooks)
 
 
-def repo_all_roles(account_number: str, commit: bool = False):
+def repo_all_roles(account_number: str, commit: bool = False, limit: int = 0):
     """
     Convenience wrapper for repo_roles() with scheduled=False.
 
@@ -205,14 +205,15 @@ def repo_all_roles(account_number: str, commit: bool = False):
     Args:
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
+        limit (int): limit number of roles to be repoed per run (0 is unlimited)
 
     Returns:
         None
     """
-    return repo_roles(account_number, commit=commit, scheduled=False)
+    return repo_roles(account_number, commit=commit, scheduled=False, limit=limit)
 
 
-def repo_scheduled_roles(account_number: str, commit: bool = False):
+def repo_scheduled_roles(account_number: str, commit: bool = False, limit: int = 0):
     """
     Convenience wrapper for repo_roles() with scheduled=True.
 
@@ -221,14 +222,17 @@ def repo_scheduled_roles(account_number: str, commit: bool = False):
     Args:
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
+        limit (int): limit number of roles to be repoed per run (0 is unlimited)
 
     Returns:
         None
     """
-    return repo_roles(account_number, commit=commit, scheduled=True)
+    return repo_roles(account_number, commit=commit, scheduled=True, limit=limit)
 
 
-def repo_roles(account_number: str, commit: bool = False, scheduled: bool = False):
+def repo_roles(
+    account_number: str, commit: bool = False, scheduled: bool = False, limit: int = 0
+):
     """
     Library wrapper to repo all scheduled or eligible roles in an account. Collect any errors and display them at the
     end.
@@ -239,13 +243,20 @@ def repo_roles(account_number: str, commit: bool = False, scheduled: bool = Fals
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
         scheduled (bool): if True only repo the scheduled roles, if False repo all the (eligible) roles
+        limit (int): limit number of roles to be repoed per run (0 is unlimited)
 
     Returns:
         None
     """
     _update_role_cache(account_number, dynamo_table, CONFIG, hooks)
     return _repo_all_roles(
-        account_number, dynamo_table, CONFIG, hooks, commit=commit, scheduled=scheduled
+        account_number,
+        dynamo_table,
+        CONFIG,
+        hooks,
+        commit=commit,
+        scheduled=scheduled,
+        limit=limit,
     )
 
 

--- a/repokid/lib/__init__.py
+++ b/repokid/lib/__init__.py
@@ -200,7 +200,7 @@ def schedule_repo(account_number: str):
 
 
 def repo_all_roles(
-    account_number: str, commit: bool = False, update: bool = True, limit: int = 0
+    account_number: str, commit: bool = False, update: bool = True, limit: int = -1
 ):
     """
     Convenience wrapper for repo_roles() with scheduled=False.
@@ -211,7 +211,7 @@ def repo_all_roles(
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
         update (bool): if True run update_role_cache before repoing
-        limit (int): limit number of roles to be repoed per run (0 is unlimited)
+        limit (int): limit number of roles to be repoed per run (< 0 is unlimited)
 
     Returns:
         None
@@ -222,7 +222,7 @@ def repo_all_roles(
 
 
 def repo_scheduled_roles(
-    account_number: str, commit: bool = False, update: bool = True, limit: int = 0
+    account_number: str, commit: bool = False, update: bool = True, limit: int = -1
 ):
     """
     Convenience wrapper for repo_roles() with scheduled=True.
@@ -233,7 +233,7 @@ def repo_scheduled_roles(
         account_number (string): The current account number Repokid is being run against
         commit (bool): actually make the changes
         update (bool): if True run update_role_cache before repoing
-        limit (int): limit number of roles to be repoed per run (0 is unlimited)
+        limit (int): limit number of roles to be repoed per run (< 0 is unlimited)
 
     Returns:
         None
@@ -248,7 +248,7 @@ def repo_roles(
     commit: bool = False,
     scheduled: bool = False,
     update: bool = True,
-    limit: int = 0,
+    limit: int = -1,
 ):
     """
     Library wrapper to repo all scheduled or eligible roles in an account. Collect any errors and display them at the
@@ -261,7 +261,7 @@ def repo_roles(
         commit (bool): actually make the changes
         scheduled (bool): if True only repo the scheduled roles, if False repo all the (eligible) roles
         update (bool): if True run update_role_cache before repoing
-        limit (int): limit number of roles to be repoed per run (0 is unlimited)
+        limit (int): limit number of roles to be repoed per run (< 0 is unlimited)
 
     Returns:
         None

--- a/repokid/tests/test_commands.py
+++ b/repokid/tests/test_commands.py
@@ -538,8 +538,18 @@ class TestRepokidCLI(object):
             ),
             call(
                 hooks,
+                "AFTER_REPO_ROLES",
+                {"account_number": None, "roles": roles_items, "errors": []},
+            ),
+            call(
+                hooks,
                 "BEFORE_REPO_ROLES",
                 {"account_number": None, "roles": [roles_items[2]]},
+            ),
+            call(
+                hooks,
+                "AFTER_REPO_ROLES",
+                {"account_number": None, "roles": [roles_items[2]], "errors": []},
             ),
         ]
 


### PR DESCRIPTION
Allow users to specify a `limit` that will limit how many roles are
repoed at one time. This is an optional kwarg that defaults to a value
of zero, which results in not limiting the repo action.

Also add `AFTER_REPO_ROLES` hook and add `errors` to the
`AFTER_REPO` hooks context.