### PR TITLE
Refactor Role model to use Pydantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Repokid is extensible via hooks that are called before, during, and after variou
 | `AFTER_REPO_ROLES` | roles, errors |
 | `BEFORE_REPO_ROLES` | account_number, roles |
 | `AFTER_SCHEDULE_REPO` | roles |
-| `DURING_REPOABLE_CALCULATION` | account_number, role_name, potentially_repoable_permissions, minimum_age |
+| `DURING_REPOABLE_CALCULATION` | role_id, account_number, role_name, potentially_repoable_permissions, minimum_age |
 | `DURING_REPOABLE_CALCULATION_BATCH` | role_batch, potentially_repoable_permissions, minimum_age |
 
 Examples of hook implementations can be found in [`repokid.hooks.loggers`](repokid/hooks/loggers/__init__.py).

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -67,15 +67,22 @@ def _update_role_cache(account_number, dynamo_table, config, hooks):
             for item in data["RolePolicyList"]
         }
 
-    roles = Roles([Role(rd) for rd in role_data])
+    roles = Roles([Role.parse_obj(rd) for rd in role_data])
 
     active_roles = []
+    updated_roles = []
     LOGGER.info("Updating role data for account {}".format(account_number))
     for role in tqdm(roles):
         role.account = account_number
         current_policies = role_data_by_id[role.role_id]["RolePolicyList"]
         active_roles.append(role.role_id)
-        roledata.update_role_data(dynamo_table, account_number, role, current_policies)
+        role = roledata.update_role_data(
+            dynamo_table, account_number, role, current_policies
+        )
+        updated_roles.append(role)
+
+    # Replace roles list with mutated Role objects
+    roles = Roles(updated_roles)
 
     LOGGER.info("Finding inactive roles in account {}".format(account_number))
     roledata.find_and_mark_inactive(dynamo_table, account_number, active_roles)
@@ -104,7 +111,7 @@ def _update_role_cache(account_number, dynamo_table, config, hooks):
         filtered_list = plugin.apply(roles)
         class_name = plugin.__class__.__name__
         for filtered_role in filtered_list:
-            LOGGER.info(
+            LOGGER.debug(
                 "Role {} filtered by {}".format(filtered_role.role_name, class_name)
             )
             filtered_role.disqualified_by.append(class_name)

--- a/repokid/commands/schedule.py
+++ b/repokid/commands/schedule.py
@@ -38,7 +38,7 @@ def _schedule_repo(account_number, dynamo_table, config, hooks):
 
     roles = Roles(
         [
-            Role(get_role_data(dynamo_table, roleID))
+            Role.parse_obj(get_role_data(dynamo_table, roleID))
             for roleID in tqdm(role_ids_for_account(dynamo_table, account_number))
         ]
     )
@@ -91,7 +91,7 @@ def _show_scheduled_roles(account_number, dynamo_table):
     """
     roles = Roles(
         [
-            Role(get_role_data(dynamo_table, roleID))
+            Role.parse_obj(get_role_data(dynamo_table, roleID))
             for roleID in tqdm(role_ids_for_account(dynamo_table, account_number))
         ]
     )
@@ -128,7 +128,7 @@ def _cancel_scheduled_repo(account_number, dynamo_table, role_name=None, is_all=
     if is_all:
         roles = Roles(
             [
-                Role(get_role_data(dynamo_table, roleID))
+                Role.parse_obj(get_role_data(dynamo_table, roleID))
                 for roleID in role_ids_for_account(dynamo_table, account_number)
             ]
         )
@@ -157,7 +157,7 @@ def _cancel_scheduled_repo(account_number, dynamo_table, role_name=None, is_all=
         )
         return
 
-    role = Role(get_role_data(dynamo_table, role_id))
+    role = Role.parse_obj(get_role_data(dynamo_table, role_id))
 
     if not role.repo_scheduled:
         LOGGER.warn(

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -11,96 +11,80 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-import copy
+from __future__ import annotations
 
-dict_to_attr = {
-    "AAData": {"attribute": "aa_data", "default": dict()},
-    "Account": {"attribute": "account", "default": None},
-    "Active": {"attribute": "active", "default": True},
-    "Arn": {"attribute": "arn", "default": None},
-    "AssumeRolePolicyDocument": {
-        "attribute": "assume_role_policy_document",
-        "default": None,
-    },
-    "CreateDate": {"attribute": "create_date", "default": None},
-    "DisqualifiedBy": {"attribute": "disqualified_by", "default": list()},
-    "NoRepoPermissions": {"attribute": "no_repo_permissions", "default": dict()},
-    "OptOut": {"attribute": "opt_out", "default": dict()},
-    "Policies": {"attribute": "policies", "default": list()},
-    "Refreshed": {"attribute": "refreshed", "default": str()},
-    "RepoablePermissions": {"attribute": "repoable_permissions", "default": int()},
-    "RepoableServices": {"attribute": "repoable_services", "default": list()},
-    "Repoed": {"attribute": "repoed", "default": str()},
-    "RepoScheduled": {"attribute": "repo_scheduled", "default": int()},
-    "RoleId": {"attribute": "role_id", "default": None},
-    "RoleName": {"attribute": "role_name", "default": None},
-    "ScheduledPerms": {"attribute": "scheduled_perms", "default": dict()},
-    "Stats": {"attribute": "stats", "default": list()},
-    "Tags": {"attribute": "tags", "default": list()},
-    "TotalPermissions": {"attribute": "total_permissions", "default": int()},
-}
+import datetime
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
-class Role(object):
-    def __init__(self, role_dict):
-        for key, value in list(dict_to_attr.items()):
-            setattr(
-                self,
-                value["attribute"],
-                role_dict[key] if key in role_dict else copy.copy(value["default"]),
-            )
+class Role(BaseModel):
+    aa_data: Optional[List] = Field(alias="AAData")
+    account: Optional[str] = Field(alias="Account")
+    active: Optional[bool] = Field(alias="Active")
+    arn: Optional[str] = Field(alias="Arn")
+    assume_role_policy_document: Dict = Field(
+        alias="AssumeRolePolicyDocument", default={}
+    )
+    create_date: Optional[datetime.datetime] = Field(alias="CreateDate")
+    disqualified_by: List = Field(alias="DisqualifiedBy", default=[])
+    no_repo_permissions: Dict = Field(alias="NoRepoPermissions", default={})
+    opt_out: Dict = Field(alias="OptOut", default={})
+    policies: List = Field(alias="Policies", default=[])
+    refreshed: Optional[str] = Field(alias="Refreshed")
+    repoable_permissions: Optional[int] = Field(alias="RepoablePermissions")
+    repoable_services: List = Field(alias="RepoableServices", default=[])
+    repoed: Optional[str] = Field(alias="Repoed")
+    repo_scheduled: Optional[int] = Field(alias="RepoScheduled")
+    role_id: Optional[str] = Field(alias="RoleId")
+    role_name: Optional[str] = Field(alias="RoleName")
+    scheduled_perms: List = Field(alias="ScheduledPerms", default=[])
+    stats: List = Field(alias="Stats", default=[])
+    tags: List = Field(alias="Tags", default=[])
+    total_permissions: Optional[int] = Field(alias="TotalPermissions")
 
-    def as_dict(self):
-        return {
-            key: getattr(self, value["attribute"])
-            for key, value in dict_to_attr.items()
-        }
-
-    def set_attributes(self, attributes_dict):
-        for key, value in attributes_dict.items():
-            setattr(self, dict_to_attr[key]["attribute"], value)
-
-    def __eq__(self, other):
+    def __eq__(self, other: str) -> bool:
         return self.role_id == other
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.role_id)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.role_id
 
 
 class Roles(object):
-    def __init__(self, role_object_list):
-        self.roles = role_object_list
+    def __init__(self, role_object_list: List[Role]):
+        self.roles: List[Role] = role_object_list
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Role:
         return self.roles[index]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.roles)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str([role.role_id for role in self.roles])
 
-    def __eq__(self, other):
+    def __eq__(self, other: Roles) -> bool:
         return all(role.role_id in other for role in self.roles) and all(
             role.role_id in self.roles for role in other
         )
 
-    def append(self, role):
+    def append(self, role: Role):
         self.roles.append(role)
 
-    def role_id_list(self):
+    def role_id_list(self) -> List[str]:
         return [role.role_id for role in self.roles]
 
-    def get_by_id(self, id):
+    def get_by_id(self, id) -> Optional[Role]:
         try:
             return self.filter(role_id=id)[0]
         except IndexError:
             return None
 
-    def filter(self, **kwargs):
+    def filter(self, **kwargs) -> List[Role]:
         roles = self.roles
         for arg, value in kwargs.items():
             roles = [role for role in roles if getattr(role, arg, None) == value]

--- a/repokid/tests/test_hooks.py
+++ b/repokid/tests/test_hooks.py
@@ -95,7 +95,7 @@ class TestHooks(object):
         }
 
         input_dict = {
-            "role_batch": [Role(ROLES[0]), "def"],
+            "role_batch": [Role.parse_obj(ROLES[0]), "def"],
             "potentially_repoable_permissions": [],
             "minimum_age": 1,
         }
@@ -106,7 +106,11 @@ class TestHooks(object):
                 hooks, "DURING_REPOABLE_CALCULATION_BATCH", input_dict
             )
 
-        input_dict["role_batch"] = [Role(ROLES[0]), Role(ROLES[1]), Role(ROLES[2])]
+        input_dict["role_batch"] = [
+            Role.parse_obj(ROLES[0]),
+            Role.parse_obj(ROLES[1]),
+            Role.parse_obj(ROLES[2]),
+        ]
         assert input_dict == repokid.hooks.call_hooks(
             hooks, "DURING_REPOABLE_CALCULATION_BATCH", input_dict
         )

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -12,6 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 from collections import defaultdict
+from typing import Dict
 import copy
 import datetime
 import logging
@@ -57,6 +58,7 @@ def add_new_policy_version(dynamo_table, role, current_policy, update_source):
     full policies including the latest.
 
     Args:
+        dynamo_table
         role (Role)
         current_policy (dict)
         update_source (string): ['Repo', 'Scan', 'Restore']
@@ -82,6 +84,7 @@ def find_and_mark_inactive(dynamo_table, account_number, active_roles):
     subtracting the active roles, any that are left are inactive and should be marked thusly.
 
     Args:
+        dynamo_table
         account_number (string)
         active_roles (set): the currently active roles discovered in the most recent scan
 
@@ -111,11 +114,11 @@ def find_newly_added_permissions(old_policy, new_policy):
     Returns:
         set: Exapnded set of permissions that are in the new policy and not the old one
     """
-    old_permissions, _ = _get_role_permissions(
-        Role({"Policies": [{"Policy": old_policy}]})
+    old_permissions, _ = get_role_permissions(
+        Role.parse_obj({"Policies": [{"Policy": old_policy}]})
     )
-    new_permissions, _ = _get_role_permissions(
-        Role({"Policies": [{"Policy": new_policy}]})
+    new_permissions, _ = get_role_permissions(
+        Role.parse_obj({"Policies": [{"Policy": new_policy}]})
     )
     return new_permissions - old_permissions
 
@@ -127,6 +130,7 @@ def update_no_repo_permissions(dynamo_table, role, newly_added_permissions):
     get deleted. Also update the role object with the new no-repo-permissions.
 
     Args:
+        dynamo_table
         role
         newly_added_permissions (set)
 
@@ -168,6 +172,7 @@ def update_opt_out(dynamo_table, role):
     Opt-out objects should have the form {'expire': xxx, 'owner': xxx, 'reason': xxx}
 
     Args:
+        dynamo_table
         role
 
     Returns:
@@ -194,6 +199,7 @@ def update_role_data(
         role (Role): current role being updated
         current_policy (dict): representation of the current policy version
         source: Default 'Scan' but could be Repo, Rollback, etc
+        add_no_repo (bool)
 
     Returns:
         None
@@ -214,7 +220,9 @@ def update_role_data(
             current_policy,
             role.tags,
         )
-        role.set_attributes(role_dict)
+        role_updates = Role.parse_obj(role_dict)
+        update_dict = role_updates.dict(exclude_unset=True)
+        role = role.copy(update=update_dict)
         LOGGER.info("Added new role ({}): {}".format(role.role_id, role.arn))
     else:
         # is the policy list the same as the last we had?
@@ -250,7 +258,13 @@ def update_role_data(
         current_role_data = get_role_data(dynamo_table, role.role_id)
         current_role_data.pop("CreateDate", None)
         current_role_data.pop("DisqualifiedBy", None)
-        role.set_attributes(current_role_data)
+
+        # Create an updated Role model to be returned to the caller
+        role_updates = Role.parse_obj(current_role_data)
+        update_dict = role_updates.dict(exclude_unset=True)
+        role = role.copy(update=update_dict)
+
+        return role
 
 
 def update_stats(dynamo_table, roles, source="Scan"):
@@ -258,6 +272,7 @@ def update_stats(dynamo_table, roles, source="Scan"):
     Create a new stats entry for each role in a set of roles and add it to Dynamo
 
     Args:
+        dynamo_table
         roles (Roles): a list of all the role objects to update data for
         source (string): the source of the new stats data (repo, scan, etc)
 
@@ -320,7 +335,7 @@ def _calculate_repo_scores(roles, minimum_age, hooks, batch=False, batch_size=10
     repo_able_roles = []
     eligible_permissions_dict = {}
     for role in roles:
-        total_permissions, eligible_permissions = _get_role_permissions(role)
+        total_permissions, eligible_permissions = get_role_permissions(role)
         role.total_permissions = len(total_permissions)
 
         # if we don't have any access advisor data for a service than nothing is repoable
@@ -351,6 +366,7 @@ def _calculate_repo_scores(roles, minimum_age, hooks, batch=False, batch_size=10
                 eligible_permissions_dict[role.arn],
                 role.aa_data,
                 role.no_repo_permissions,
+                role.role_id,
                 minimum_age,
                 hooks,
             )
@@ -401,7 +417,7 @@ def _convert_repoable_perms_to_perms_and_services(
                 perm for perm in repoable_perms_by_service[service]
             )
 
-    return (sorted(repoed_permissions), sorted(repoed_services))
+    return sorted(repoed_permissions), sorted(repoed_services)
 
 
 def _convert_repoed_service_to_sorted_perms_and_services(repoed_services):
@@ -427,7 +443,7 @@ def _convert_repoed_service_to_sorted_perms_and_services(repoed_services):
         else:
             repoable_services.add(entry)
 
-    return (sorted(repoable_permissions), sorted(repoable_services))
+    return sorted(repoable_permissions), sorted(repoable_services)
 
 
 def _filter_scheduled_repoable_perms(repoable_permissions, scheduled_perms):
@@ -436,7 +452,7 @@ def _filter_scheduled_repoable_perms(repoable_permissions, scheduled_perms):
 
     Args:
         repoable_permissions (list): List of expanded permissions that are currently believed repoable
-        scheduled_permissions (list): List of scheduled permissions and services (stored in Dynamo at schedule time)
+        scheduled_perms (list): List of scheduled permissions and services (stored in Dynamo at schedule time)
     Returns:
         list: New (filtered) repoable permissions
     """
@@ -464,17 +480,17 @@ def _get_epoch_authenticated(service_authenticated):
     """
     current_time = int(time.time())
     if service_authenticated == 0:
-        return (0, True)
+        return 0, True
 
     # we have an odd timestamp, try to check
     elif BEGINNING_OF_2015_MILLI_EPOCH < service_authenticated < (current_time * 1000):
-        return (service_authenticated / 1000, True)
+        return service_authenticated / 1000, True
 
     elif (BEGINNING_OF_2015_MILLI_EPOCH / 1000) < service_authenticated < current_time:
-        return (service_authenticated, True)
+        return service_authenticated, True
 
     else:
-        return (None, False)
+        return None, False
 
 
 def _get_potentially_repoable_permissions(
@@ -548,6 +564,7 @@ def _get_repoable_permissions(
     permissions,
     aa_data,
     no_repo_permissions,
+    role_id,
     minimum_age,
     hooks,
 ):
@@ -563,7 +580,7 @@ def _get_repoable_permissions(
     Args:
         account_number
         role_name
-        permissions (list): The full list of permissions that the role's permissions allow
+        permissions (set): The full set of permissions that the role's permissions allow
         aa_data (list): A list of Access Advisor data for a role. Each element is a dictionary with a couple required
                         attributes: lastAuthenticated (epoch time in milliseconds when the service was last used and
                         serviceNamespace (the service used)
@@ -591,6 +608,7 @@ def _get_repoable_permissions(
             "role_name": role_name,
             "potentially_repoable_permissions": potentially_repoable_permissions,
             "minimum_age": minimum_age,
+            "role_id": role_id,
         },
     )
 
@@ -702,7 +720,7 @@ def _get_repoable_permissions_batch(
     return repoable_set_dict
 
 
-def _get_repoed_policy(policies, repoable_permissions):
+def _get_repoed_policy(policies: Dict, repoable_permissions: set):
     """
     This function contains the logic to rewrite the policy to remove any repoable permissions. To do so we:
       - Iterate over role policies
@@ -807,12 +825,12 @@ def _get_permissions_in_policy(policy_dict, warn_unknown_perms=False):
 
     weird_permissions = total_permissions.difference(all_permissions)
     if weird_permissions and warn_unknown_perms:
-        LOGGER.warn("Unknown permissions found: {}".format(weird_permissions))
+        LOGGER.warning("Unknown permissions found: {}".format(weird_permissions))
 
     return total_permissions, eligible_permissions
 
 
-def _get_role_permissions(role, warn_unknown_perms=False):
+def get_role_permissions(role, warn_unknown_perms=False):
     """
     Expand the most recent version of policies from a role to produce a list of all the permissions that are allowed
     (permission is included in one or more statements that is allowed).  To perform expansion the policyuniverse
@@ -822,13 +840,16 @@ def _get_role_permissions(role, warn_unknown_perms=False):
 
     Args:
         role (Role): The role object that we're getting a list of permissions for
+        warn_unknown_perms (bool)
 
     Returns:
         tuple
         set - all permissions allowed by the policies
         set - all permisisons allowed by the policies not marked with STATEMENT_SKIP_SID
     """
-    return _get_permissions_in_policy(role.policies[-1]["Policy"])
+    return _get_permissions_in_policy(
+        role.policies[-1]["Policy"], warn_unknown_perms=warn_unknown_perms
+    )
 
 
 def _get_services_in_permissions(permissions_set):
@@ -875,14 +896,16 @@ def partial_update_role_data(
         role (Role)
         dynamo_table
         account_number
+        config
         conn (dict)
+        hooks
         source: repo, rollback, etc
         add_no_repo: if set to True newly discovered permissions will be added to no repo list
 
     Returns:
         None
     """
-    current_policies = get_role_inline_policies(role.as_dict(), **conn) or {}
+    current_policies = get_role_inline_policies(role.dict(), **conn) or {}
     update_role_data(
         dynamo_table,
         account_number,

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -12,11 +12,11 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 from collections import defaultdict
-from typing import Dict
 import copy
 import datetime
 import logging
 import time
+from typing import Dict
 
 from cloudaux.aws.iam import get_role_inline_policies
 from dateutil.tz import tzlocal

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -224,6 +224,7 @@ def update_role_data(
         update_dict = role_updates.dict(exclude_unset=True)
         role = role.copy(update=update_dict)
         LOGGER.info("Added new role ({}): {}".format(role.role_id, role.arn))
+        return role
     else:
         # is the policy list the same as the last we had?
         old_policy = stored_role["Policies"][-1]["Policy"]

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ tabulate
 tabview
 tqdm
 pip-tools
+pydantic
 pytz
 twine
 raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ packaging==20.4           # via bleach
 pip-tools==5.2.1          # via -r requirements.in
 pkginfo==1.5.0.1          # via twine
 policyuniverse==1.3.2.3   # via -r requirements.in
+pydantic==1.7.2           # via -r requirements.in
 pygments==2.6.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via botocore

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     url="https://github.com/Netflix/repokid",
     packages=find_packages(),
     install_requires=REQUIRED,
+    python_requires=">=3.7",
     keywords=["aws", "iam", "access_advisor"],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
- Refactor Role model to use Pydantic
- Call `Role.parse_obj()` to instantiate roles from dicts
- Refactor `update_role_data()` to not mutate role object, but instead return an updated instance
- Send `role_id` to `DURING_REPOABLE_CALCULATION` hook
- Update tests for all of the above