### PR TITLE
Migrate to click for repokid CLI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 import-order-style = google
-application-import-names=google
+application-import-names = repokid

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+    python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.4.0  # Use the ref you want to point at
@@ -23,7 +25,6 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
 
 -   repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-case-conflict
     -   id: check-yaml
     -   id: flake8
-        args: []
+        args: ["--exclude", "venv/,.tox/,.eggs/"]
     -   id: pretty-format-json
         args: ["--autofix"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,27 +2,34 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0  # Use the ref you want to point at
+    rev: v3.3.0  # Use the ref you want to point at
     hooks:
     -   id: trailing-whitespace
-    -   id: autopep8-wrapper
     -   id: check-ast
     -   id: check-case-conflict
     -   id: check-yaml
-    -   id: flake8
-        args: ["--exclude", "venv/,.tox/,.eggs/"]
     -   id: pretty-format-json
         args: ["--autofix"]
 
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5.4
+    hooks:
+        -   id: autopep8
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    -   id: flake8
+        args: ["--exclude", "venv/,.tox/,.eggs/"]
+
 -   repo: https://github.com/pycqa/isort
-    rev: 5.6.3
+    rev: 5.6.4
     hooks:
       - id: isort
-        name: isort (python)
         args: ["--sl"]
 
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
     -   id: pretty-format-json
         args: ["--autofix"]
 
+-   repo: https://github.com/pycqa/isort
+    rev: 5.6.3
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--sl"]
+
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,5 @@ deploy:
     tags: true
 notifications:
   email:
-  - tmcpeak@netflix.com
   - ccastrapel@netflix.com
   - psanders@netflix.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
 - pip install -r requirements.txt -r requirements-test.txt
 - pip install .
 script:
+- pre-commit run
 - coverage run --source repokid -m py.test
 - bandit -r . -ll -ii -x repokid/tests/
-- pre-commit run
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: focal
 matrix:
   include:
   - python: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: python
 matrix:
   include:
   - python: '3.7'
+  - python: '3.8'
+  - python: '3.9'
 before_install:
 - sudo rm -f /etc/boto.cfg
 install:
+- pip install -r requirements.txt -r requirements-test.txt
 - pip install .
-- pip install -r requirements-test.txt
 script:
 - coverage run --source repokid -m py.test
 - bandit -r . -ll -ii -x repokid/tests/
-- flake8 .
-- black .
+- pre-commit run
 after_success:
 - coveralls
 deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please follow the instructions in Repokid's [getting started](https://github.com
 
 Issue Tags
 ----------
-First time contributors should consider tackling an issue marked with `difficulty:newcomer` first.  These issues are relatively easy and a good way to get started.  
+First time contributors should consider tackling an issue marked with `difficulty:newcomer` first.  These issues are relatively easy and a good way to get started.
 
 We also have some issues tagged with `help wanted`.  These issues are something we'd love help with and are a great way to get significantly involved with the project.
 

--- a/repokid/cli/dispatcher_cli.py
+++ b/repokid/cli/dispatcher_cli.py
@@ -3,10 +3,13 @@ import inspect
 import json
 
 from cloudaux.aws.sts import sts_conn
-from marshmallow import fields, post_load, Schema
-from repokid import CONFIG
+from marshmallow import Schema
+from marshmallow import fields
+from marshmallow import post_load
+
 import repokid.dispatcher
 import repokid.utils.dynamo as dynamo
+from repokid import CONFIG
 
 
 class Message(object):

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -12,9 +12,10 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-import click
 import json
 import logging
+
+import click
 
 from repokid import CONFIG
 from repokid import get_hooks

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -19,24 +19,18 @@ import click
 
 from repokid import CONFIG
 from repokid import get_hooks
-from repokid.commands.repo import (
-    _repo_all_roles,
-    _repo_role,
-    _repo_stats,
-    _rollback_role,
-)
-from repokid.commands.role import (
-    _display_role,
-    _display_roles,
-    _find_roles_with_permissions,
-    _remove_permissions_from_roles,
-)
+from repokid.commands.repo import _repo_all_roles
+from repokid.commands.repo import _repo_role
+from repokid.commands.repo import _repo_stats
+from repokid.commands.repo import _rollback_role
+from repokid.commands.role import _display_role
+from repokid.commands.role import _display_roles
+from repokid.commands.role import _find_roles_with_permissions
+from repokid.commands.role import _remove_permissions_from_roles
 from repokid.commands.role_cache import _update_role_cache
-from repokid.commands.schedule import (
-    _cancel_scheduled_repo,
-    _schedule_repo,
-    _show_scheduled_roles,
-)
+from repokid.commands.schedule import _cancel_scheduled_repo
+from repokid.commands.schedule import _schedule_repo
+from repokid.commands.schedule import _show_scheduled_roles
 from repokid.utils.dynamo import dynamo_get_or_create_table
 
 logger = logging.getLogger("repokid")

--- a/repokid/cli/repokid_cli.py
+++ b/repokid/cli/repokid_cli.py
@@ -188,14 +188,14 @@ def cli(ctx):
 
 
 @cli.command()
-@click.argument("filename",)
+@click.argument("filename")
 @click.pass_context
 def config(ctx, filename):
     _generate_default_config(filename=filename)
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.pass_context
 def update_role_cache(ctx, account_number):
     dynamo_table = ctx.obj["dynamo_table"]
@@ -205,7 +205,7 @@ def update_role_cache(ctx, account_number):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.option("--inactive", default=False, help="Include inactive roles")
 @click.pass_context
 def display_role_cache(ctx, account_number, inactive):
@@ -214,9 +214,7 @@ def display_role_cache(ctx, account_number, inactive):
 
 
 @cli.command()
-@click.argument(
-    "permissions", nargs=-1,
-)
+@click.argument("permissions", nargs=-1)
 @click.option("--output", "-o", required=False, help="File to write results to")
 @click.pass_context
 def find_roles_with_permissions(ctx, permissions, output):
@@ -225,9 +223,7 @@ def find_roles_with_permissions(ctx, permissions, output):
 
 
 @cli.command()
-@click.argument(
-    "permissions", nargs=-1,
-)
+@click.argument("permissions", nargs=-1)
 @click.option("--role-file", "-f", required=True, help="File to read roles from")
 @click.option("--commit", "-c", default=False, help="Commit changes")
 @click.pass_context
@@ -240,8 +236,8 @@ def remove_permissions_from_roles(ctx, permissions, role_file, commit):
 
 
 @cli.command()
-@click.argument("account_number",)
-@click.argument("role_name",)
+@click.argument("account_number")
+@click.argument("role_name")
 @click.pass_context
 def display_role(ctx, account_number, role_name):
     dynamo_table = ctx.obj["dynamo_table"]
@@ -251,8 +247,8 @@ def display_role(ctx, account_number, role_name):
 
 
 @cli.command()
-@click.argument("account_number",)
-@click.argument("role_name",)
+@click.argument("account_number")
+@click.argument("role_name")
 @click.option("--commit", "-c", default=False, help="Commit changes")
 @click.pass_context
 def repo_role(ctx, account_number, role_name, commit):
@@ -263,8 +259,8 @@ def repo_role(ctx, account_number, role_name, commit):
 
 
 @cli.command()
-@click.argument("account_number",)
-@click.argument("role_name",)
+@click.argument("account_number")
+@click.argument("role_name")
 @click.option("--selection", "-s", required=True, type=int)
 @click.option("--commit", "-c", default=False, help="Commit changes")
 @click.pass_context
@@ -284,7 +280,7 @@ def rollback_role(ctx, account_number, role_name, selection, commit):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.option("--commit", "-c", default=False, help="Commit changes")
 @click.pass_context
 def repo_all_roles(ctx, account_number, commit):
@@ -299,7 +295,7 @@ def repo_all_roles(ctx, account_number, commit):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.pass_context
 def schedule_repo(ctx, account_number):
     dynamo_table = ctx.obj["dynamo_table"]
@@ -311,7 +307,7 @@ def schedule_repo(ctx, account_number):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.pass_context
 def show_scheduled_roles(ctx, account_number):
     dynamo_table = ctx.obj["dynamo_table"]
@@ -319,7 +315,7 @@ def show_scheduled_roles(ctx, account_number):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.option("--role", "-r", required=False, type=str)
 @click.option("--all", "-a", default=False, help="Commit changes")
 @click.pass_context
@@ -329,7 +325,7 @@ def cancel_scheduled_repo(ctx, account_number, role, all):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.option("--commit", "-c", default=False, help="Commit changes")
 @click.pass_context
 def repo_scheduled_roles(ctx, account_number, commit):
@@ -343,7 +339,7 @@ def repo_scheduled_roles(ctx, account_number, commit):
 
 
 @cli.command()
-@click.argument("account_number",)
+@click.argument("account_number")
 @click.option("--output", "-o", required=True, help="File to write results to")
 @click.pass_context
 def repo_stats(ctx, account_number, output):

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -19,30 +19,26 @@ import pprint
 import time
 
 import botocore
-from cloudaux.aws.iam import (
-    delete_role_policy,
-    get_role_inline_policies,
-    put_role_policy,
-)
+from cloudaux.aws.iam import delete_role_policy
+from cloudaux.aws.iam import get_role_inline_policies
+from cloudaux.aws.iam import put_role_policy
+from tabulate import tabulate
+
 import repokid.hooks
-from repokid.role import Role, Roles
+from repokid.role import Role
+from repokid.role import Roles
 from repokid.utils import roledata as roledata
-from repokid.utils.dynamo import (
-    find_role_in_cache,
-    get_role_data,
-    role_ids_for_account,
-    role_ids_for_all_accounts,
-    set_role_data,
-)
-from repokid.utils.iam import (
-    delete_policy,
-    inline_policies_size_exceeds_maximum,
-    replace_policies,
-    update_repoed_description,
-)
+from repokid.utils.dynamo import find_role_in_cache
+from repokid.utils.dynamo import get_role_data
+from repokid.utils.dynamo import role_ids_for_account
+from repokid.utils.dynamo import role_ids_for_all_accounts
+from repokid.utils.dynamo import set_role_data
+from repokid.utils.iam import delete_policy
+from repokid.utils.iam import inline_policies_size_exceeds_maximum
+from repokid.utils.iam import replace_policies
+from repokid.utils.iam import update_repoed_description
 from repokid.utils.logging import log_deleted_and_repoed_policies
 from repokid.utils.roledata import partial_update_role_data
-from tabulate import tabulate
 
 LOGGER = logging.getLogger("repokid")
 
@@ -318,8 +314,10 @@ def _rollback_role(
             )
 
         except botocore.exceptions.ClientError as e:
-            message = "Unable to push policy {}.  Error: {} (role: {} account {})".format(
-                policy_name, e.message, role.role_name, account_number
+            message = (
+                "Unable to push policy {}.  Error: {} (role: {} account {})".format(
+                    policy_name, e.message, role.role_name, account_number
+                )
             )
             LOGGER.error(message, exc_info=True)
             errors.append(message)

--- a/repokid/commands/role.py
+++ b/repokid/commands/role.py
@@ -15,23 +15,21 @@ import csv
 import json
 import logging
 
-from policyuniverse.arn import ARN
-import repokid.hooks
-from repokid.role import Role, Roles
-from repokid.utils import roledata as roledata
-from repokid.utils.dynamo import (
-    find_role_in_cache,
-    get_role_data,
-    role_ids_for_account,
-    role_ids_for_all_accounts,
-)
-from repokid.utils.iam import (
-    inline_policies_size_exceeds_maximum,
-    remove_permissions_from_role,
-)
-from tabulate import tabulate
 import tabview as t
+from policyuniverse.arn import ARN
+from tabulate import tabulate
 from tqdm import tqdm
+
+import repokid.hooks
+from repokid.role import Role
+from repokid.role import Roles
+from repokid.utils import roledata as roledata
+from repokid.utils.dynamo import find_role_in_cache
+from repokid.utils.dynamo import get_role_data
+from repokid.utils.dynamo import role_ids_for_account
+from repokid.utils.dynamo import role_ids_for_all_accounts
+from repokid.utils.iam import inline_policies_size_exceeds_maximum
+from repokid.utils.iam import remove_permissions_from_role
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -14,12 +14,14 @@
 import logging
 
 from cloudaux.aws.iam import get_account_authorization_details
+from tqdm import tqdm
+
 from repokid.filters import FilterPlugins
-from repokid.role import Role, Roles
+from repokid.role import Role
+from repokid.role import Roles
 from repokid.utils import roledata as roledata
 from repokid.utils.aardvark import get_aardvark_data
 from repokid.utils.dynamo import set_role_data
-from tqdm import tqdm
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/commands/schedule.py
+++ b/repokid/commands/schedule.py
@@ -11,20 +11,20 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-from datetime import datetime as dt
 import logging
 import time
+from datetime import datetime as dt
 
-import repokid.hooks
-from repokid.role import Role, Roles
-from repokid.utils.dynamo import (
-    find_role_in_cache,
-    get_role_data,
-    role_ids_for_account,
-    set_role_data,
-)
 from tabulate import tabulate
 from tqdm import tqdm
+
+import repokid.hooks
+from repokid.role import Role
+from repokid.role import Roles
+from repokid.utils.dynamo import find_role_in_cache
+from repokid.utils.dynamo import get_role_data
+from repokid.utils.dynamo import role_ids_for_account
+from repokid.utils.dynamo import set_role_data
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/dispatcher/__init__.py
+++ b/repokid/dispatcher/__init__.py
@@ -1,12 +1,12 @@
-from collections import namedtuple
 import datetime
 import time
+from collections import namedtuple
 
-from repokid import CONFIG
-from repokid import get_hooks
 import repokid.commands.repo
 import repokid.utils.dynamo as dynamo
 import repokid.utils.roledata as roledata
+from repokid import CONFIG
+from repokid import get_hooks
 
 ResponderReturn = namedtuple("ResponderReturn", "successful, return_message")
 

--- a/repokid/filters/age/__init__.py
+++ b/repokid/filters/age/__init__.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from dateutil.tz import tzlocal
+
 from repokid.filters import Filter
 
 LOGGER = logging.getLogger("repokid")

--- a/repokid/filters/blocklist/__init__.py
+++ b/repokid/filters/blocklist/__init__.py
@@ -3,6 +3,7 @@ import logging
 
 import botocore
 from cloudaux.aws.sts import boto3_cached_conn
+
 from repokid.exceptions import BlocklistError
 from repokid.filters import Filter
 

--- a/repokid/lib/__init__.py
+++ b/repokid/lib/__init__.py
@@ -21,26 +21,19 @@ from typing import Optional
 
 from repokid import CONFIG
 from repokid import get_hooks
-from repokid.commands.repo import (
-    _repo_all_roles,
-    _repo_role,
-    _repo_stats,
-    _rollback_role,
-)
-from repokid.commands.role import (
-    _display_role,
-    _display_roles,
-    _find_roles_with_permissions,
-    _remove_permissions_from_roles,
-)
+from repokid.commands.repo import _repo_all_roles
+from repokid.commands.repo import _repo_role
+from repokid.commands.repo import _repo_stats
+from repokid.commands.repo import _rollback_role
+from repokid.commands.role import _display_role
+from repokid.commands.role import _display_roles
+from repokid.commands.role import _find_roles_with_permissions
+from repokid.commands.role import _remove_permissions_from_roles
 from repokid.commands.role_cache import _update_role_cache
-from repokid.commands.schedule import (
-    _cancel_scheduled_repo,
-    _schedule_repo,
-    _show_scheduled_roles,
-)
+from repokid.commands.schedule import _cancel_scheduled_repo
+from repokid.commands.schedule import _schedule_repo
+from repokid.commands.schedule import _show_scheduled_roles
 from repokid.utils.dynamo import dynamo_get_or_create_table
-
 
 hooks = get_hooks(CONFIG.get("hooks", ["repokid.hooks.loggers"]))
 dynamo_table = dynamo_get_or_create_table(**CONFIG["dynamo_db"])

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -14,9 +14,12 @@
 from __future__ import annotations
 
 import datetime
-from typing import Dict, List, Optional
+from typing import Dict
+from typing import List
+from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from pydantic import Field
 
 
 class Role(BaseModel):

--- a/repokid/tests/test_commands.py
+++ b/repokid/tests/test_commands.py
@@ -16,17 +16,21 @@ import logging
 import time
 
 from dateutil.tz import tzlocal
-from mock import call, MagicMock, mock_open, patch
+from mock import MagicMock
+from mock import call
+from mock import mock_open
+from mock import patch
+
 import repokid.cli.repokid_cli
 import repokid.commands.repo
 import repokid.commands.role
 import repokid.commands.role_cache
 import repokid.commands.schedule
-from repokid.role import Role, Roles
 import repokid.utils.iam
 import repokid.utils.logging
 import repokid.utils.roledata
-
+from repokid.role import Role
+from repokid.role import Roles
 
 AARDVARK_DATA = {
     "arn:aws:iam::123456789012:role/all_services_used": [
@@ -790,7 +794,8 @@ class TestRepokidCLI(object):
     @patch("repokid.utils.iam.set_role_data", MagicMock(return_value=None))
     @patch("repokid.utils.iam.set_role_data", MagicMock(return_value=None))
     @patch(
-        "repokid.utils.iam.update_repoed_description", MagicMock(return_value=None),
+        "repokid.utils.iam.update_repoed_description",
+        MagicMock(return_value=None),
     )
     @patch("repokid.utils.iam.roledata.update_role_data", MagicMock(return_value=None))
     def test_remove_permissions_from_role(self):

--- a/repokid/tests/test_dispatcher_cli.py
+++ b/repokid/tests/test_dispatcher_cli.py
@@ -1,12 +1,13 @@
 import copy
 import datetime
 
-from marshmallow import ValidationError
-from mock import call, patch
 import pytest
+from marshmallow import ValidationError
+from mock import call
+from mock import patch
+
 import repokid.cli.dispatcher_cli as dispatcher_cli
 import repokid.dispatcher as dispatcher
-
 
 DYNAMO_TABLE = None
 MESSAGE = dispatcher_cli.Message(

--- a/repokid/tests/test_hooks.py
+++ b/repokid/tests/test_hooks.py
@@ -12,11 +12,13 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 import pytest
+
 import repokid.cli.repokid_cli
 import repokid.hooks
 from repokid.hooks.loggers import log_during_repoable_calculation_batch_hooks
 from repokid.role import Role
-from repokid.tests.artifacts.hook import function_1, function_2
+from repokid.tests.artifacts.hook import function_1
+from repokid.tests.artifacts.hook import function_2
 from repokid.tests.test_commands import ROLES
 
 

--- a/repokid/tests/test_logging.py
+++ b/repokid/tests/test_logging.py
@@ -1,4 +1,5 @@
 from mock import patch
+
 from repokid.utils.logging import JSONFormatter
 
 

--- a/repokid/tests/test_roledata.py
+++ b/repokid/tests/test_roledata.py
@@ -14,9 +14,11 @@
 import time
 from unittest.mock import patch
 
-from repokid.role import Role
-from repokid.tests.test_commands import AARDVARK_DATA, ROLE_POLICIES, ROLES
 import repokid.utils.roledata
+from repokid.role import Role
+from repokid.tests.test_commands import AARDVARK_DATA
+from repokid.tests.test_commands import ROLE_POLICIES
+from repokid.tests.test_commands import ROLES
 
 # AARDVARK_DATA maintained in test_repokid_cli
 
@@ -483,11 +485,14 @@ class TestRoledata(object):
         ]
         expected_services = ["ec2", "route53"]
         expected_permissions = ["dynamodb:def", "s3:abc", "ses:ghi", "ses:jkl"]
-        assert repokid.utils.roledata._convert_repoed_service_to_sorted_perms_and_services(
-            repoed_services
-        ) == (
-            expected_permissions,
-            expected_services,
+        assert (
+            repokid.utils.roledata._convert_repoed_service_to_sorted_perms_and_services(
+                repoed_services
+            )
+            == (
+                expected_permissions,
+                expected_services,
+            )
         )
 
     def test_get_epoch_authenticated(self):
@@ -516,7 +521,7 @@ class TestRoledata(object):
         ) == ["a:b", "a:c"]
 
     def test_get_repoed_policy_sid(self):
-        """ roledata._get_repoed_policy(policies, repoable_permissions)
+        """roledata._get_repoed_policy(policies, repoable_permissions)
 
         Cases to consider:
 
@@ -573,7 +578,7 @@ class TestRoledata(object):
         )
 
     def test_get_permissions_in_policy_sid(self):
-        """ roledata._get_permissions_in_policy(policy_dict, warn_unkown_perms=False)
+        """roledata._get_permissions_in_policy(policy_dict, warn_unkown_perms=False)
 
         returns total_permissions, eligible_permissions
 

--- a/repokid/utils/aardvark.py
+++ b/repokid/utils/aardvark.py
@@ -13,8 +13,9 @@
 #     limitations under the License.
 import logging
 
-from repokid.exceptions import AardvarkError
 import requests
+
+from repokid.exceptions import AardvarkError
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
-from functools import wraps
 import logging
+from functools import wraps
 
 import boto3
 from botocore.exceptions import ClientError as BotoClientError

--- a/repokid/utils/iam.py
+++ b/repokid/utils/iam.py
@@ -18,11 +18,10 @@ import re
 
 import botocore
 from cloudaux import sts_conn
-from cloudaux.aws.iam import (
-    delete_role_policy,
-    get_role_inline_policies,
-    put_role_policy,
-)
+from cloudaux.aws.iam import delete_role_policy
+from cloudaux.aws.iam import get_role_inline_policies
+from cloudaux.aws.iam import put_role_policy
+
 from repokid.utils import roledata as roledata
 from repokid.utils.dynamo import set_role_data
 from repokid.utils.logging import log_deleted_and_repoed_policies

--- a/repokid/utils/logging.py
+++ b/repokid/utils/logging.py
@@ -11,11 +11,11 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-from datetime import datetime
 import json
 import logging
-from socket import gethostname
 import traceback
+from datetime import datetime
+from socket import gethostname
 
 LOGGER = logging.getLogger("repokid")
 

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -11,27 +11,28 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
-from collections import defaultdict
 import copy
 import datetime
 import logging
 import time
+from collections import defaultdict
 from typing import Dict
 
 from cloudaux.aws.iam import get_role_inline_policies
 from dateutil.tz import tzlocal
-from policyuniverse import all_permissions, expand_policy, get_actions_from_statement
-from repokid import CONFIG as CONFIG
+from policyuniverse import all_permissions
+from policyuniverse import expand_policy
+from policyuniverse import get_actions_from_statement
+
 import repokid.hooks
+from repokid import CONFIG as CONFIG
 from repokid.role import Role
 from repokid.utils.aardvark import get_aardvark_data
-from repokid.utils.dynamo import (
-    add_to_end_of_list,
-    get_role_data,
-    role_ids_for_account,
-    set_role_data,
-    store_initial_role_data,
-)
+from repokid.utils.dynamo import add_to_end_of_list
+from repokid.utils.dynamo import get_role_data
+from repokid.utils.dynamo import role_ids_for_account
+from repokid.utils.dynamo import set_role_data
+from repokid.utils.dynamo import store_initial_role_data
 
 LOGGER = logging.getLogger("repokid")
 BEGINNING_OF_2015_MILLI_EPOCH = 1420113600000

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -3,6 +3,7 @@ black
 coveralls
 flake8
 flake8-import-order
+pre-commit
 python-dateutil
 mock
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,46 +4,53 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements-test.txt requirements-test.in
 #
-appdirs==1.4.4            # via black
+appdirs==1.4.4            # via black, virtualenv
 attrs==20.3.0             # via pytest
 bandit==1.6.2             # via -r requirements-test.in
 black==20.8b1             # via -r requirements-test.in
 certifi==2020.11.8        # via requests
+cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via requests
 click==7.1.2              # via black
 coverage==5.3             # via coveralls
 coveralls==2.1.2          # via -r requirements-test.in
+distlib==0.3.1            # via virtualenv
 docopt==0.6.2             # via coveralls
+filelock==3.0.12          # via virtualenv
 flake8-import-order==0.18.1  # via -r requirements-test.in
 flake8==3.8.4             # via -r requirements-test.in
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.11         # via bandit
+identify==1.5.10          # via pre-commit
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via flake8, pluggy, pytest, stevedore
+importlib-metadata==2.0.0  # via flake8, pluggy, pre-commit, pytest, stevedore, virtualenv
 iniconfig==1.1.1          # via pytest
 mccabe==0.6.1             # via flake8
 mock==4.0.2               # via -r requirements-test.in
 mypy-extensions==0.4.3    # via black
+nodeenv==1.5.0            # via pre-commit
 packaging==20.4           # via pytest
 pathspec==0.8.1           # via black
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via pytest
+pre-commit==2.9.0         # via -r requirements-test.in
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8, flake8-import-order
 pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via packaging
 pytest==6.1.2             # via -r requirements-test.in
 python-dateutil==2.8.1    # via -r requirements-test.in
-pyyaml==5.3.1             # via bandit
+pyyaml==5.3.1             # via bandit, pre-commit
 regex==2020.11.13         # via black
 requests==2.25.0          # via coveralls
-six==1.15.0               # via bandit, packaging, python-dateutil
+six==1.15.0               # via bandit, packaging, python-dateutil, virtualenv
 smmap==3.0.4              # via gitdb
 stevedore==3.2.2          # via bandit
-toml==0.10.2              # via black, pytest
+toml==0.10.2              # via black, pre-commit, pytest
 typed-ast==1.4.1          # via black
 typing-extensions==3.7.4.3  # via black
 urllib3==1.26.2           # via requests
+virtualenv==20.2.1        # via pre-commit
 zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 boto3
 cloudaux
-docopt
+click
 import_string
 marshmallow
 policyuniverse

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,10 @@ boto==2.49.0              # via cloudaux
 botocore==1.19.22         # via boto3, cloudaux, s3transfer
 certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
-click==7.1.2              # via pip-tools
+click==7.1.2              # via -r requirements.in, pip-tools
 cloudaux==1.9.0           # via -r requirements.in
 colorama==0.4.4           # via twine
 defusedxml==0.6.0         # via cloudaux
-docopt==0.6.2             # via -r requirements.in
 docutils==0.16            # via readme-renderer
 flagpole==1.1.1           # via cloudaux
 idna==2.10                # via requests

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-from setuptools import find_packages, setup
-
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="repokid",


### PR DESCRIPTION
Use Click instead of docopt for more explicit definitions of CLI commands.

By default, Click replaces underscores with hyphens when converting methods to CLI commands. I've included the `AliasedGroup` class to make sure we stay compatible with the "old" style with underscores. The CLI is otherwise compatible with previous versions.

This PR also includes a bunch of shuffling of imports, resulting from trying to make the build and pre-commit flows more consistent. Sorry.