### PR TITLE
Add persistence methods to Role model

### DIFF
--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -77,7 +77,7 @@ def _update_role_cache(
             for item in data["RolePolicyList"]
         }
 
-    roles = RoleList([Role.parse_obj(rd) for rd in role_data])
+    roles = RoleList([Role(**rd) for rd in role_data])
 
     active_roles = RoleList([])
     updated_roles = RoleList([])

--- a/repokid/exceptions.py
+++ b/repokid/exceptions.py
@@ -29,3 +29,15 @@ class RoleNotFoundError(Exception):
 
 class IAMError(Exception):
     pass
+
+
+class RoleModelError(AttributeError):
+    pass
+
+
+class DynamoDBError(Exception):
+    pass
+
+
+class IntegrityError(Exception):
+    pass

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -23,34 +23,77 @@ from typing import Set
 from typing import Union
 from typing import overload
 
+from mypy_boto3_dynamodb.service_resource import Table
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import PrivateAttr
+
+from repokid import CONFIG
+from repokid.exceptions import IntegrityError
+from repokid.exceptions import RoleModelError
+from repokid.exceptions import RoleNotFoundError
+from repokid.types import RepokidConfig
+from repokid.utils.aardvark import get_aardvark_data
+from repokid.utils.dynamo_v2 import create_dynamodb_entry
+from repokid.utils.dynamo_v2 import dynamo_get_or_create_table
+from repokid.utils.dynamo_v2 import get_role_by_id
+from repokid.utils.dynamo_v2 import get_role_by_name
+from repokid.utils.dynamo_v2 import set_role_data
+
+
+def to_camel(string: str) -> str:
+    return "".join(word.capitalize() for word in string.split("_"))
 
 
 class Role(BaseModel):
     aa_data: Optional[List[Dict[str, Any]]] = Field(alias="AAData")
-    account: str = Field(alias="Account", default="")
-    active: Optional[bool] = Field(alias="Active")
-    arn: str = Field(alias="Arn", default="")
-    assume_role_policy_document: Dict[str, Any] = Field(
-        alias="AssumeRolePolicyDocument", default={}
-    )
-    create_date: Optional[datetime.datetime] = Field(alias="CreateDate")
-    disqualified_by: List[str] = Field(alias="DisqualifiedBy", default=[])
-    no_repo_permissions: Dict[str, Any] = Field(alias="NoRepoPermissions", default={})
-    opt_out: Dict[str, int] = Field(alias="OptOut", default={})
-    policies: List[Dict[str, Any]] = Field(alias="Policies", default=[])
-    refreshed: Optional[str] = Field(alias="Refreshed")
-    repoable_permissions: int = Field(alias="RepoablePermissions", default=0)
-    repoable_services: List[str] = Field(alias="RepoableServices", default=[])
-    repoed: Optional[str] = Field(alias="Repoed")
-    repo_scheduled: float = Field(alias="RepoScheduled", default=0.0)
-    role_id: str = Field(alias="RoleId", default="")
-    role_name: str = Field(alias="RoleName", default="")
-    scheduled_perms: Set[str] = Field(alias="ScheduledPerms", default=[])
-    stats: List[Dict[str, Any]] = Field(alias="Stats", default=[])
-    tags: List[Dict[str, Any]] = Field(alias="Tags", default=[])
-    total_permissions: Optional[int] = Field(alias="TotalPermissions")
+    account: str = Field(default="")
+    active: Optional[bool] = Field()
+    arn: str = Field(default="")
+    assume_role_policy_document: Dict[str, Any] = Field(default={})
+    create_date: Optional[datetime.datetime] = Field()
+    disqualified_by: List[str] = Field(default=[])
+    last_updated: datetime.datetime = Field(default_factory=datetime.datetime.now)
+    no_repo_permissions: Dict[str, Any] = Field(default={})
+    opt_out: Dict[str, int] = Field(default={})
+    policies: List[Dict[str, Any]] = Field(default=[])
+    refreshed: Optional[str] = Field()
+    repoable_permissions: int = Field(default=0)
+    repoable_services: List[str] = Field(default=[])
+    repoed: Optional[str] = Field()
+    repo_scheduled: float = Field(default=0.0)
+    role_id: str = Field(default="")
+    role_name: str = Field(default="")
+    scheduled_perms: Set[str] = Field(default=[])
+    stats: List[Dict[str, Any]] = Field(default=[])
+    tags: List[Dict[str, Any]] = Field(default=[])
+    total_permissions: Optional[int] = Field()
+    config: RepokidConfig = Field(default=CONFIG)
+    _dirty: bool = PrivateAttr(default=False)
+    _default_store_args = {
+        "by_alias": True,
+        "exclude": {
+            "role_id",
+            "role_name",
+            "account",
+            "config",
+            "_dirty",
+            "_dynamo_table",
+            "_updated_fields",
+        },
+    }
+    _dynamo_table: Table = PrivateAttr()
+    _updated_fields: Set[str] = PrivateAttr(default_factory=set)
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        underscore_attrs_are_private = True
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._dynamo_table = dynamo_get_or_create_table(**self.config["dynamo_db"])
 
     def __eq__(self, other: object) -> bool:
         return self.role_id == other
@@ -60,6 +103,85 @@ class Role(BaseModel):
 
     def __repr__(self) -> str:
         return f"<Role {self.role_id}>"
+
+    def update(self, values: Dict[str, Any], store: bool = True) -> None:
+        self._dirty = True
+        self._updated_fields.update(values.keys())
+        self.parse_obj(values)
+        if store:
+            self.store()
+
+    def fetch_aa_data(self, config: RepokidConfig):
+        if not self.arn:
+            raise RoleModelError(
+                "missing arn on Role instance, cannot retrieve Access Advisor data"
+            )
+
+        aardvark_data = get_aardvark_data(
+            config.get("aardvark_api_location"), arn=self.arn
+        )
+
+        self.aa_data = aardvark_data.get(self.arn)
+
+    def fetch(self, fields: Optional[List[str]] = None, update: bool = True):
+        if self._dirty:
+            raise IntegrityError(
+                "role object has unsaved modifications, fetching may overwrite changes"
+            )
+
+        if self.role_id:
+            role_data = get_role_by_id(self._dynamo_table, self.role_id, fields=fields)
+        elif self.role_name and self.account:
+            role_data = get_role_by_name(
+                self._dynamo_table, self.account, self.role_name, fields=fields
+            )
+        else:
+            raise RoleModelError(
+                "missing role_id or role_name and account on Role instance"
+            )
+
+        if role_data and update:
+            self.parse_obj(role_data)
+
+    def store(self, fields: Optional[List[str]] = None):
+        try:
+            remote_dt = get_role_by_id(
+                self._dynamo_table, self.role_id, fields=["LastUpdated"]
+            ).get("LastUpdated")
+            remote_last_updated = datetime.datetime.strptime(
+                remote_dt, "%Y-%m-%d %H:%M"
+            )
+            if remote_last_updated > self.last_updated:
+                raise IntegrityError("stored role has been updated since last fetch")
+        except RoleNotFoundError:
+            pass
+
+        self.last_updated = datetime.datetime.now()
+
+        try:
+            self.fetch(fields=fields, update=False)
+        except RoleNotFoundError:
+            create_dynamodb_entry(self._dynamo_table, self.dict())
+            self._updated_fields = set()
+
+        if fields:
+            set_role_data(
+                self._dynamo_table,
+                self.role_id,
+                self.dict(
+                    include=set(fields).add("last_updated"),
+                    **self._default_store_args,
+                ),
+            )
+            self._updated_fields - set(fields)
+        else:
+            set_role_data(
+                self._dynamo_table,
+                self.role_id,
+                self.dict(exclude_unset=True, **self._default_store_args),
+            )
+            self._updated_fields = set()
+        self._dirty = False
 
 
 class RoleList(object):

--- a/repokid/tests/conftest.py
+++ b/repokid/tests/conftest.py
@@ -1,0 +1,59 @@
+import pytest
+
+from repokid.tests import vars
+
+
+@pytest.fixture(scope="session")
+def role_dict():
+    return {
+        "aa_data": vars.aa_data,
+        "account": vars.account,
+        "active": vars.active,
+        "arn": vars.arn,
+        "assume_role_policy_document": vars.assume_role_policy_document,
+        "create_date": vars.create_date,
+        "disqualified_by": vars.disqualified_by,
+        "last_updated": vars.last_updated,
+        "no_repo_permissions": vars.no_repo_permissions,
+        "opt_out": vars.opt_out,
+        "policies": vars.policies,
+        "refreshed": vars.refreshed,
+        "repoable_permissions": vars.repoable_permissions,
+        "repoable_services": vars.repoable_services,
+        "repoed": vars.repoed,
+        "repo_scheduled": vars.repo_scheduled,
+        "role_id": vars.role_id,
+        "role_name": vars.role_name,
+        "scheduled_perms": vars.scheduled_perms,
+        "stats": vars.stats,
+        "tags": vars.tags,
+        "total_permissions": vars.total_permissions,
+    }
+
+
+@pytest.fixture(scope="session")
+def role_dict_with_aliases():
+    return {
+        "AAData": vars.aa_data,
+        "Account": vars.account,
+        "Active": vars.active,
+        "Arn": vars.arn,
+        "AssumeRolePolicyDocument": vars.assume_role_policy_document,
+        "CreateDate": vars.create_date,
+        "DisqualifiedBy": vars.disqualified_by,
+        "LastUpdated": vars.last_updated,
+        "NoRepoPermissions": vars.no_repo_permissions,
+        "OptOut": vars.opt_out,
+        "Policies": vars.policies,
+        "Refreshed": vars.refreshed,
+        "RepoablePermissions": vars.repoable_permissions,
+        "RepoableServices": vars.repoable_services,
+        "Repoed": vars.repoed,
+        "RepoScheduled": vars.repo_scheduled,
+        "RoleId": vars.role_id,
+        "RoleName": vars.role_name,
+        "ScheduledPerms": vars.scheduled_perms,
+        "Stats": vars.stats,
+        "Tags": vars.tags,
+        "TotalPermissions": vars.total_permissions,
+    }

--- a/repokid/tests/test_commands.py
+++ b/repokid/tests/test_commands.py
@@ -203,8 +203,8 @@ ROLES = [
 ]
 
 ROLES_FOR_DISPLAY = [
-    Role.parse_obj(
-        {
+    Role(
+        **{
             "TotalPermissions": 4,
             "RepoablePermissions": 0,
             "Repoed": "Never",
@@ -212,8 +212,8 @@ ROLES_FOR_DISPLAY = [
             "Refreshed": "Someday",
         }
     ),
-    Role.parse_obj(
-        {
+    Role(
+        **{
             "TotalPermissions": 4,
             "RepoablePermissions": 2,
             "Repoed": "Never",
@@ -221,8 +221,8 @@ ROLES_FOR_DISPLAY = [
             "Refreshed": "Someday",
         }
     ),
-    Role.parse_obj(
-        {
+    Role(
+        **{
             "TotalPermissions": 4,
             "RepoablePermissions": 0,
             "Repoed": "Never",
@@ -230,8 +230,8 @@ ROLES_FOR_DISPLAY = [
             "Refreshed": "Someday",
         }
     ),
-    Role.parse_obj(
-        {
+    Role(
+        **{
             "TotalPermissions": 4,
             "RepoablePermissions": 0,
             "Repoed": "Never",
@@ -239,8 +239,8 @@ ROLES_FOR_DISPLAY = [
             "Refreshed": "Someday",
         }
     ),
-    Role.parse_obj(
-        {
+    Role(
+        **{
             "TotalPermissions": 4,
             "RepoablePermissions": 2,
             "Repoed": "Never",
@@ -248,8 +248,8 @@ ROLES_FOR_DISPLAY = [
             "Refreshed": "Someday",
         }
     ),
-    Role.parse_obj(
-        {
+    Role(
+        **{
             "TotalPermissions": 4,
             "RepoablePermissions": 2,
             "Repoed": "Never",
@@ -329,9 +329,9 @@ class TestRepokidCLI(object):
 
         roles = RoleList(
             [
-                Role.parse_obj(ROLES[0]),
-                Role.parse_obj(ROLES[1]),
-                Role.parse_obj(ROLES[2]),
+                Role(**ROLES[0]),
+                Role(**ROLES[1]),
+                Role(**ROLES[2]),
             ]
         )
 
@@ -344,19 +344,19 @@ class TestRepokidCLI(object):
             call(
                 dynamo_table,
                 account_number,
-                Role.parse_obj(ROLES[0]),
+                Role(**ROLES[0]),
                 {"all_services_used": ROLE_POLICIES["all_services_used"]},
             ),
             call(
                 dynamo_table,
                 account_number,
-                Role.parse_obj(ROLES[1]),
+                Role(**ROLES[1]),
                 {"unused_ec2": ROLE_POLICIES["unused_ec2"]},
             ),
             call(
                 dynamo_table,
                 account_number,
-                Role.parse_obj(ROLES[2]),
+                Role(**ROLES[2]),
                 {"all_services_used": ROLE_POLICIES["all_services_used"]},
             ),
         ]
@@ -368,9 +368,9 @@ class TestRepokidCLI(object):
                 account_number,
                 RoleList(
                     [
-                        Role.parse_obj(ROLES[0]),
-                        Role.parse_obj(ROLES[1]),
-                        Role.parse_obj(ROLES[2]),
+                        Role(**ROLES[0]),
+                        Role(**ROLES[1]),
+                        Role(**ROLES[2]),
                     ]
                 ),
             )
@@ -406,7 +406,7 @@ class TestRepokidCLI(object):
         test_roles = []
         for x, role in enumerate(ROLES_FOR_DISPLAY):
             test_roles.append(
-                role.copy(update=Role.parse_obj(ROLES[x]).dict(exclude_unset=True))
+                role.copy(update=Role(**ROLES[x]).dict(exclude_unset=True))
             )
 
         # loop over all roles twice (one for each call below)
@@ -484,13 +484,13 @@ class TestRepokidCLI(object):
         # first role is not repoable, second role is repoable
         test_roles = [
             ROLES_FOR_DISPLAY[0].copy(
-                update=Role.parse_obj({"RoleId": "AROAABCDEFGHIJKLMNOPA"}).dict(
+                update=Role(**{"RoleId": "AROAABCDEFGHIJKLMNOPA"}).dict(
                     exclude_unset=True
                 )
             ),
             ROLES_FOR_DISPLAY[1].copy(
-                update=Role.parse_obj(
-                    {"RoleId": "AROAABCDEFGHIJKLMNOPB", "AAData": [{"foo": "bar"}]}
+                update=Role(
+                    **{"RoleId": "AROAABCDEFGHIJKLMNOPB", "AAData": [{"foo": "bar"}]}
                 ).dict(exclude_unset=True)
             ),
         ]
@@ -537,8 +537,8 @@ class TestRepokidCLI(object):
         ]
         roles = RoleList(
             [
-                Role.parse_obj(
-                    {
+                Role(
+                    **{
                         "Arn": "arn:aws:iam::123456789012:role/ROLE_A",
                         "RoleId": "AROAABCDEFGHIJKLMNOPA",
                         "Active": True,
@@ -548,8 +548,8 @@ class TestRepokidCLI(object):
                         - datetime.timedelta(days=100),
                     }
                 ),
-                Role.parse_obj(
-                    {
+                Role(
+                    **{
                         "Arn": "arn:aws:iam::123456789012:role/ROLE_B",
                         "RoleId": "AROAABCDEFGHIJKLMNOPB",
                         "Active": True,
@@ -559,8 +559,8 @@ class TestRepokidCLI(object):
                         - datetime.timedelta(days=100),
                     }
                 ),
-                Role.parse_obj(
-                    {
+                Role(
+                    **{
                         "Arn": "arn:aws:iam::123456789012:role/ROLE_C",
                         "RoleId": "AROAABCDEFGHIJKLMNOPC",
                         "Active": True,
@@ -644,8 +644,8 @@ class TestRepokidCLI(object):
         ]
         roles = RoleList(
             [
-                Role.parse_obj(
-                    {
+                Role(
+                    **{
                         "Arn": "arn:aws:iam::123456789012:role/ROLE_A",
                         "RoleId": "AROAABCDEFGHIJKLMNOPA",
                         "Active": True,
@@ -655,8 +655,8 @@ class TestRepokidCLI(object):
                         - datetime.timedelta(days=100),
                     }
                 ),
-                Role.parse_obj(
-                    {
+                Role(
+                    **{
                         "Arn": "arn:aws:iam::123456789012:role/ROLE_B",
                         "RoleId": "AROAABCDEFGHIJKLMNOPB",
                         "Active": True,
@@ -666,8 +666,8 @@ class TestRepokidCLI(object):
                         - datetime.timedelta(days=100),
                     }
                 ),
-                Role.parse_obj(
-                    {
+                Role(
+                    **{
                         "Arn": "arn:aws:iam::123456789012:role/ROLE_C",
                         "RoleId": "AROAABCDEFGHIJKLMNOPC",
                         "Active": True,

--- a/repokid/tests/test_hooks.py
+++ b/repokid/tests/test_hooks.py
@@ -97,7 +97,7 @@ class TestHooks(object):
         }
 
         input_dict = {
-            "role_batch": [Role.parse_obj(ROLES[0]), "def"],
+            "role_batch": [Role(**ROLES[0]), "def"],
             "potentially_repoable_permissions": [],
             "minimum_age": 1,
         }
@@ -109,9 +109,9 @@ class TestHooks(object):
             )
 
         input_dict["role_batch"] = [
-            Role.parse_obj(ROLES[0]),
-            Role.parse_obj(ROLES[1]),
-            Role.parse_obj(ROLES[2]),
+            Role(**ROLES[0]),
+            Role(**ROLES[1]),
+            Role(**ROLES[2]),
         ]
         assert input_dict == repokid.hooks.call_hooks(
             hooks, "DURING_REPOABLE_CALCULATION_BATCH", input_dict

--- a/repokid/tests/test_role.py
+++ b/repokid/tests/test_role.py
@@ -1,0 +1,166 @@
+import copy
+
+import pytest
+from unittest.mock import patch
+
+from repokid.exceptions import RoleModelError
+from repokid.role import Role, update
+from repokid.tests import vars
+
+
+def test_create_role(role_dict):
+    r = Role(**role_dict)
+    assert r
+    assert r.aa_data == vars.aa_data
+    assert r.active == vars.active
+    assert r.arn == vars.arn
+    assert r.assume_role_policy_document == vars.assume_role_policy_document
+    assert r.create_date == vars.create_date
+    assert r.disqualified_by == vars.disqualified_by
+    assert r.last_updated == vars.last_updated
+    assert r.no_repo_permissions == vars.no_repo_permissions
+    assert r.opt_out == vars.opt_out
+    assert r.policies == vars.policies
+    assert r.refreshed == vars.refreshed
+    assert r.repoable_permissions == vars.repoable_permissions
+    assert r.repoable_services == vars.repoable_services
+    assert r.repoed == vars.repoed
+    assert r.repo_scheduled == vars.repo_scheduled
+    assert r.role_id == vars.role_id
+    assert r.role_name == vars.role_name
+    assert r.scheduled_perms == vars.scheduled_perms
+    assert r.stats == vars.stats
+    assert r.tags == vars.tags
+    assert r.total_permissions == vars.total_permissions
+
+
+def test_create_role_from_aliases(role_dict_with_aliases):
+    r = Role(**role_dict_with_aliases)
+    assert r
+    assert r.aa_data == vars.aa_data
+    assert r.active == vars.active
+    assert r.arn == vars.arn
+    assert r.assume_role_policy_document == vars.assume_role_policy_document
+    assert r.create_date == vars.create_date
+    assert r.disqualified_by == vars.disqualified_by
+    assert r.last_updated == vars.last_updated
+    assert r.no_repo_permissions == vars.no_repo_permissions
+    assert r.opt_out == vars.opt_out
+    assert r.policies == vars.policies
+    assert r.refreshed == vars.refreshed
+    assert r.repoable_permissions == vars.repoable_permissions
+    assert r.repoable_services == vars.repoable_services
+    assert r.repoed == vars.repoed
+    assert r.repo_scheduled == vars.repo_scheduled
+    assert r.role_id == vars.role_id
+    assert r.role_name == vars.role_name
+    assert r.scheduled_perms == vars.scheduled_perms
+    assert r.stats == vars.stats
+    assert r.tags == vars.tags
+    assert r.total_permissions == vars.total_permissions
+
+
+def test_role_update(role_dict):
+    r = Role(**role_dict)
+    updates = {"repoable_permissions": 20}
+    r.update(updates, store=False)
+    assert r.repoable_permissions == 20
+
+
+def test_role_update_by_alias(role_dict):
+    r = Role(**role_dict)
+    updates = {"RepoablePermissions": 20}
+    r.update(updates, store=False)
+    assert r.repoable_permissions == 20
+
+
+@patch("repokid.role.get_aardvark_data")
+def test_role_fetch_aa_data(mock_get_aardvark_data, role_dict):
+    mock_get_aardvark_data.return_value = {vars.arn: [{"a": "b"}]}
+    r = Role(**role_dict)
+    r.fetch_aa_data()
+    assert r.aa_data[0]
+
+
+def test_role_fetch_aa_data_no_arn(role_dict):
+    role_data = copy.deepcopy(role_dict)
+    role_data.pop("arn")
+    r = Role(**role_data)
+    with pytest.raises(RoleModelError):
+        r.fetch_aa_data()
+
+
+@patch("repokid.role.get_role_by_id")
+def test_role_fetch(mock_get_role_by_id, role_dict):
+    stored_role_data = copy.deepcopy(role_dict)
+    stored_role_data["repoable_permissions"] = 20
+    mock_get_role_by_id.return_value = stored_role_data
+    r = Role(**role_dict)
+    assert r.repoable_permissions == 5
+    r.fetch()
+    assert r.repoable_permissions == 20
+
+
+@patch("repokid.role.get_role_by_name")
+def test_role_fetch_no_id(mock_get_role_by_name, role_dict):
+    stored_role_data = copy.deepcopy(role_dict)
+    stored_role_data["repoable_permissions"] = 20
+    mock_get_role_by_name.return_value = stored_role_data
+    local_role_data = copy.deepcopy(role_dict)
+    local_role_data.pop("role_id")
+    r = Role(**local_role_data)
+    assert r.repoable_permissions == 5
+    r.fetch()
+    assert r.repoable_permissions == 20
+
+
+def test_role_fetch_not_found(role_dict):
+    local_role_data = copy.deepcopy(role_dict)
+    local_role_data.pop("role_id")
+    local_role_data.pop("role_name")
+    local_role_data.pop("account")
+    r = Role(**local_role_data)
+    with pytest.raises(RoleModelError):
+        r.fetch()
+
+
+@patch("repokid.role.get_role_by_id")
+@patch("repokid.role.set_role_data")
+def test_role_store(mock_set_role_data, mock_get_role_by_id, role_dict, role_dict_with_aliases):
+    expected = copy.deepcopy(role_dict_with_aliases)
+    expected.pop("RoleId")
+    expected.pop("RoleName")
+    expected.pop("Account")
+    mock_get_role_by_id.return_value = {"LastUpdated": vars.last_updated.strftime("%Y-%m-%d %H:%M")}
+    r = Role(**role_dict)
+    r.store()
+    mock_set_role_data.assert_called_once()
+    assert mock_set_role_data.call_args[0][0] == r.role_id
+    # LastUpdated gets set when we store, so we just need to make sure it's different now
+    assert mock_set_role_data.call_args[0][1]["LastUpdated"] > expected["LastUpdated"]
+
+    # Remove LastUpdated from the fn call and expected dict so we can compare the rest
+    mock_set_role_data.call_args[0][1].pop("LastUpdated")
+    expected.pop("LastUpdated")
+
+    assert mock_set_role_data.call_args[0][1] == expected
+
+
+@patch("repokid.role.get_role_by_id")
+@patch("repokid.role.set_role_data")
+def test_role_store_fields(mock_set_role_data, mock_get_role_by_id, role_dict, role_dict_with_aliases):
+    expected = {"RepoablePermissions": 5, "LastUpdated": vars.last_updated}
+    mock_get_role_by_id.return_value = {"LastUpdated": vars.last_updated.strftime("%Y-%m-%d %H:%M")}
+    r = Role(**role_dict)
+    r.store(fields=["repoable_permissions"])
+    mock_set_role_data.assert_called_once()
+    assert mock_set_role_data.call_args[0][0] == r.role_id
+    # LastUpdated gets set when we store, so we just need to make sure it's different now
+    assert mock_set_role_data.call_args[0][1]["LastUpdated"] > expected["LastUpdated"]
+
+    # Remove LastUpdated from the fn call and expected dict so we can compare the rest
+    mock_set_role_data.call_args[0][1].pop("LastUpdated")
+    expected.pop("LastUpdated")
+
+    assert mock_set_role_data.call_args[0][1] == expected
+

--- a/repokid/tests/test_roledata.py
+++ b/repokid/tests/test_roledata.py
@@ -30,7 +30,7 @@ class TestRoledata(object):
     def test_get_role_permissions(
         self, mock_all_permissions, mock_get_actions_from_statement, mock_expand_policy
     ):
-        test_role = Role.parse_obj(ROLES[0])
+        test_role = Role(**ROLES[0])
 
         all_permissions = [
             "ec2:associateaddress",
@@ -146,9 +146,9 @@ class TestRoledata(object):
     @patch("repokid.hooks.call_hooks")
     def test_get_repoable_permissions_batch(self, mock_call_hooks):
         roles = [
-            Role.parse_obj(ROLES[0]),
-            Role.parse_obj(ROLES[4]),
-            Role.parse_obj(ROLES[5]),
+            Role(**ROLES[0]),
+            Role(**ROLES[4]),
+            Role(**ROLES[5]),
         ]
 
         roles[0].aa_data = AARDVARK_DATA[roles[0].arn]
@@ -273,9 +273,9 @@ class TestRoledata(object):
         self, mock_call_hooks, mock_get_repoable_permissions, mock_get_role_permissions
     ):
         roles = [
-            Role.parse_obj(ROLES[0]),
-            Role.parse_obj(ROLES[1]),
-            Role.parse_obj(ROLES[2]),
+            Role(**ROLES[0]),
+            Role(**ROLES[1]),
+            Role(**ROLES[2]),
         ]
         roles[0].disqualified_by = []
         roles[0].aa_data = "some_aa_data"
@@ -340,11 +340,11 @@ class TestRoledata(object):
         mock_get_role_permissions,
     ):
         roles = [
-            Role.parse_obj(ROLES[0]),
-            Role.parse_obj(ROLES[1]),
-            Role.parse_obj(ROLES[2]),
-            Role.parse_obj(ROLES[4]),
-            Role.parse_obj(ROLES[5]),
+            Role(**ROLES[0]),
+            Role(**ROLES[1]),
+            Role(**ROLES[2]),
+            Role(**ROLES[4]),
+            Role(**ROLES[5]),
         ]
         roles[0].disqualified_by = []
         roles[0].aa_data = "some_aa_data"

--- a/repokid/tests/vars.py
+++ b/repokid/tests/vars.py
@@ -1,0 +1,24 @@
+import datetime
+
+aa_data = [{}]
+account = "123456789012"
+active = True
+arn = f"arn:aws:iam:{account}::role/TestRole"
+assume_role_policy_document = {}
+create_date = datetime.datetime.now() - datetime.timedelta(days=10)
+disqualified_by = [""]
+last_updated = datetime.datetime.now() - datetime.timedelta(hours=2)
+no_repo_permissions = {}
+opt_out = {}
+policies = [{}]
+refreshed = ""
+repoable_permissions = 5
+repoable_services = [""]
+repoed = ""
+repo_scheduled = 0.0
+role_id = "ARIOABC123BLAHBLAHBLAH"
+role_name = "TestRole"
+scheduled_perms = {""}
+stats = [{}]
+tags = [{}]
+total_permissions = 5

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -219,7 +219,7 @@ def get_role_data(
         response = dynamo_table.get_item(Key={"RoleId": roleID})
 
     if response and "Item" in response:
-        return Role.parse_obj(_empty_string_from_dynamo_replace(response["Item"]))
+        return Role(**_empty_string_from_dynamo_replace(response["Item"]))
     else:
         raise RoleNotFoundError(f"Role ID {roleID} not found in DynamoDB")
 

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -8,6 +8,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Set
+from typing import TypeVar
 from typing import Union
 
 import boto3
@@ -22,6 +23,7 @@ from repokid.role import Role
 LOGGER = logging.getLogger("repokid")
 # used as a placeholder for empty SID to work around this: https://github.com/aws/aws-sdk-js/issues/833
 DYNAMO_EMPTY_STRING = "---DYNAMO-EMPTY-STRING---"
+T = TypeVar("T", str, Dict[Any, Any], List[Any])
 
 
 def catch_boto_error(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -374,9 +376,7 @@ def store_initial_role_data(
     return role_dict
 
 
-def _empty_string_from_dynamo_replace(
-    obj: Union[Dict[str, Any], List[Any]]
-) -> Union[Dict[str, Any], List[Any]]:
+def _empty_string_from_dynamo_replace(obj: T) -> T:
     """
     Traverse a potentially nested object and replace all Dynamo placeholders with actual empty strings
 

--- a/repokid/utils/dynamo_v2.py
+++ b/repokid/utils/dynamo_v2.py
@@ -1,0 +1,244 @@
+import datetime
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+
+import boto3
+from botocore.exceptions import ClientError as BotoClientError
+from cloudaux.aws.sts import boto3_cached_conn
+from mypy_boto3_dynamodb.service_resource import Table
+from mypy_boto3_dynamodb.type_defs import GlobalSecondaryIndexTypeDef
+
+from repokid.exceptions import RoleNotFoundError
+
+DYNAMO_EMPTY_STRING = "---DYNAMO-EMPTY-STRING---"
+
+logger = logging.getLogger("repokid")
+
+
+def _empty_string_from_dynamo_replace(
+    obj: Union[Dict[str, Any], List[Any]]
+) -> Union[Dict[str, Any], List[Any]]:
+    """
+    Traverse a potentially nested object and replace all Dynamo placeholders with actual empty strings
+
+    Args:
+        obj (object)
+
+    Returns:
+        object: Object with original empty strings
+    """
+    if isinstance(obj, dict):
+        return {k: _empty_string_from_dynamo_replace(v) for k, v in list(obj.items())}
+    elif isinstance(obj, list):
+        return [_empty_string_from_dynamo_replace(elem) for elem in obj]
+    else:
+        if str(obj) == DYNAMO_EMPTY_STRING:
+            obj = ""
+        return obj
+
+
+def _empty_string_to_dynamo_replace(
+    obj: Union[Dict[str, Any], List[Any]]
+) -> Union[Dict[str, Any], List[Any]]:
+    """
+    Traverse a potentially nested object and replace all instances of an empty string with a placeholder
+
+    Args:
+        obj (object)
+
+    Returns:
+        object: Object with Dynamo friendly empty strings
+    """
+    if isinstance(obj, dict):
+        return {k: _empty_string_to_dynamo_replace(v) for k, v in list(obj.items())}
+    elif isinstance(obj, list):
+        return [_empty_string_to_dynamo_replace(elem) for elem in obj]
+    else:
+        try:
+            if str(obj) == "":
+                obj = DYNAMO_EMPTY_STRING
+        except UnicodeEncodeError:
+            obj = DYNAMO_EMPTY_STRING
+        return obj
+
+
+def _datetime_to_string_replace(
+    obj: Union[Dict[str, Any], List[Any]]
+) -> Union[Dict[str, Any], List[Any]]:
+    if isinstance(obj, dict):
+        return {k: _datetime_to_string_replace(v) for k, v in list(obj.items())}
+    elif isinstance(obj, list):
+        return [_datetime_to_string_replace(elem) for elem in obj]
+    else:
+        if isinstance(obj, datetime.datetime):
+            obj = obj.strftime("%Y-%m-%d %H:%M")
+        return obj
+
+
+def dynamo_get_or_create_table(
+    account_number: str,
+    session_name: str,
+    region: str,
+    endpoint: str,
+    assume_role: Optional[str] = "",
+) -> Table:
+    """
+    Create a new table or get a reference to an existing Dynamo table named 'repokid_roles' that will store data all
+    data for Repokid.  Return a table with a reference to the dynamo resource
+
+    Args:
+        account_number (string)
+        assume_role (string) optional
+        session_name (string)
+        region (string)
+        endpoint (string)
+
+    Returns:
+        dynamo_table object
+    """
+    if "localhost" in endpoint:
+        resource = boto3.resource(
+            "dynamodb", region_name="us-east-1", endpoint_url=endpoint
+        )
+    else:
+        resource = boto3_cached_conn(
+            "dynamodb",
+            service_type="resource",
+            account_number=account_number,
+            assume_role=assume_role or None,
+            session_name=session_name,
+            region=region,
+        )
+
+    for table in resource.tables.all():
+        if table.name == "repokid_roles":
+            return table
+
+    table = resource.create_table(
+        TableName="repokid_roles",
+        KeySchema=[{"AttributeName": "RoleId", "KeyType": "HASH"}],  # Partition key
+        AttributeDefinitions=[
+            {"AttributeName": "RoleId", "AttributeType": "S"},
+            {"AttributeName": "RoleName", "AttributeType": "S"},
+            {"AttributeName": "Account", "AttributeType": "S"},
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 50, "WriteCapacityUnits": 50},
+        GlobalSecondaryIndexes=[
+            GlobalSecondaryIndexTypeDef(
+                {
+                    "IndexName": "Account",
+                    "KeySchema": [{"AttributeName": "Account", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 10,
+                        "WriteCapacityUnits": 10,
+                    },
+                }
+            ),
+            GlobalSecondaryIndexTypeDef(
+                {
+                    "IndexName": "RoleName",
+                    "KeySchema": [{"AttributeName": "RoleName", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 10,
+                        "WriteCapacityUnits": 10,
+                    },
+                }
+            ),
+        ],
+    )
+
+    return table
+
+
+def create_dynamodb_entry(dynamo_table: Table, values: Dict[str, Any]) -> None:
+    try:
+        dynamo_table.put_item(Item=values)
+    except BotoClientError:
+        logger.error("failed to create dynamodb item")
+        logger.debug("dynamodb creation failure details", extra={"values": values})
+        raise
+
+
+def get_role_by_id(
+    dynamo_table: Table, role_id: str, fields: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    if fields:
+        response = dynamo_table.get_item(
+            Key={"RoleId": role_id}, AttributesToGet=fields
+        )
+    else:
+        response = dynamo_table.get_item(Key={"RoleId": role_id})
+
+    if response and "Item" in response:
+        return _empty_string_from_dynamo_replace(response["Item"])
+    else:
+        raise RoleNotFoundError(f"Role ID {role_id} not found in DynamoDB")
+
+
+def get_role_by_name(
+    dynamo_table: Table,
+    account_id: str,
+    role_name: str,
+    fields: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    results = dynamo_table.query(
+        IndexName="RoleName",
+        KeyConditionExpression="RoleName = :rn",
+        ExpressionAttributeValues={":rn": role_name},
+    )
+    items = results.get("Items")
+    if len(items) < 1:
+        raise RoleNotFoundError(f"{role_name} in {account_id} not found in DynamoDB")
+
+    if len(items) > 1:
+        # multiple results, so we'll grab the first match that's active
+        for r in items:
+            if r.get("Active"):
+                return r
+
+    # we only have one result
+    return items[0]
+
+
+def set_role_data(
+    dynamo_table: Table, role_id: str, update_keys: Dict[str, Any]
+) -> None:
+    if not update_keys:
+        return
+
+    update_expression = "SET "
+    expression_attribute_names = {}
+    expression_attribute_values = {}
+    count = 0
+    for key, value in update_keys.items():
+        count += 1
+
+        if count > 1:
+            update_expression += ", "
+
+        value = _empty_string_to_dynamo_replace(value)
+        value = _datetime_to_string_replace(value)
+
+        update_expression += f"#expr{count} = :val{count}"
+        expression_attribute_names[f"#expr{count}"] = key
+        expression_attribute_values[f":val{count}"] = value
+
+    update_item_inputs = {
+        "Key": {"RoleId": role_id},
+        "UpdateExpression": update_expression,
+        "ExpressionAttributeNames": expression_attribute_names,
+        "ExpressionAttributeValues": expression_attribute_values,
+    }
+    logger.debug("updating dynamodb with inputs %s", update_item_inputs)
+    dynamo_table.update_item(
+        Key={"RoleId": role_id},
+        UpdateExpression=update_expression,
+        ExpressionAttributeNames=expression_attribute_names,
+        ExpressionAttributeValues=expression_attribute_values,
+    )

--- a/repokid/utils/dynamo_v2.py
+++ b/repokid/utils/dynamo_v2.py
@@ -254,4 +254,9 @@ def set_role_data(
     )
 
 
-ROLE_TABLE = dynamo_get_or_create_table(**CONFIG["dynamo_db"])
+dynamodb_config = CONFIG.get("dynamo_db")
+if dynamodb_config:
+    ROLE_TABLE = dynamo_get_or_create_table(**CONFIG["dynamo_db"])
+else:
+    logger.warning("No DynamoDB config found; not creating table")
+    ROLE_TABLE = None

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -244,7 +244,7 @@ def update_role_data(
             current_policy,
             role.tags,
         )
-        role_updates = Role.parse_obj(role_dict)
+        role_updates = Role(**role_dict)
         update_dict = role_updates.dict(exclude_unset=True)
         role = role.copy(update=update_dict)
         LOGGER.info("Added new role ({}): {}".format(role.role_id, role.arn))

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,14 +6,14 @@
 #
 appdirs==1.4.4            # via black, virtualenv
 attrs==20.3.0             # via pytest
-bandit==1.6.2             # via -r requirements-test.in
+bandit==1.6.3             # via -r requirements-test.in
 black==20.8b1             # via -r requirements-test.in
-certifi==2020.11.8        # via requests
+certifi==2020.12.5        # via requests
 cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via requests
 click==7.1.2              # via black
 coverage==5.3             # via coveralls
-coveralls==2.1.2          # via -r requirements-test.in
+coveralls==2.2.0          # via -r requirements-test.in
 distlib==0.3.1            # via virtualenv
 docopt==0.6.2             # via coveralls
 filelock==3.0.12          # via virtualenv
@@ -23,18 +23,18 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.11         # via bandit
 identify==1.5.10          # via pre-commit
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via flake8, pluggy, pre-commit, pytest, stevedore, virtualenv
+importlib-metadata==3.1.1  # via flake8, pluggy, pre-commit, pytest, stevedore, virtualenv
 iniconfig==1.1.1          # via pytest
 mccabe==0.6.1             # via flake8
-mock==4.0.2               # via -r requirements-test.in
+mock==4.0.3               # via -r requirements-test.in
 mypy-extensions==0.4.3    # via black, mypy
 mypy==0.790               # via -r requirements-test.in
 nodeenv==1.5.0            # via pre-commit
-packaging==20.4           # via pytest
+packaging==20.7           # via pytest
 pathspec==0.8.1           # via black
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via pytest
-pre-commit==2.9.0         # via -r requirements-test.in
+pre-commit==2.9.3         # via -r requirements-test.in
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8, flake8-import-order
 pyflakes==2.2.0           # via flake8
@@ -44,14 +44,14 @@ python-dateutil==2.8.1    # via -r requirements-test.in
 pyyaml==5.3.1             # via bandit, pre-commit
 regex==2020.11.13         # via black
 requests==2.25.0          # via coveralls
-six==1.15.0               # via bandit, packaging, python-dateutil, virtualenv
+six==1.15.0               # via bandit, python-dateutil, virtualenv
 smmap==3.0.4              # via gitdb
-stevedore==3.2.2          # via bandit
+stevedore==3.3.0          # via bandit
 toml==0.10.2              # via black, pre-commit, pytest
 typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.3  # via black, mypy
 urllib3==1.26.2           # via requests
-virtualenv==20.2.1        # via pre-commit
+virtualenv==20.2.2        # via pre-commit
 zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@
 #    pip-compile --no-emit-index-url --output-file=requirements.txt requirements.in
 #
 bleach==3.2.1             # via readme-renderer
-boto3-stubs[dynamodb,iam,sns,sqs]==1.16.25.0  # via -r requirements.in
-boto3==1.16.22            # via -r requirements.in, cloudaux
+boto3-stubs[dynamodb,iam,sns,sqs]==1.16.34.0  # via -r requirements.in
+boto3==1.16.35            # via -r requirements.in, cloudaux
 boto==2.49.0              # via cloudaux
-botocore==1.19.22         # via boto3, cloudaux, s3transfer
-certifi==2020.11.8        # via requests
+botocore==1.19.35         # via boto3, cloudaux, s3transfer
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements.in, pip-tools
 cloudaux==1.9.0           # via -r requirements.in
@@ -19,22 +19,22 @@ docutils==0.16            # via readme-renderer
 flagpole==1.1.1           # via cloudaux
 idna==2.10                # via requests
 import-string==0.1.0      # via -r requirements.in
-importlib-metadata==2.0.0  # via keyring, twine
+importlib-metadata==3.1.1  # via keyring, twine
 inflection==0.5.1         # via cloudaux
 jmespath==0.10.0          # via boto3, botocore
 joblib==0.17.0            # via cloudaux
 json-log-formatter==0.3.0  # via -r requirements.in
 keyring==21.5.0           # via twine
-mypy-boto3-dynamodb==1.16.25.0  # via boto3-stubs
-mypy-boto3-iam==1.16.25.0  # via boto3-stubs
-mypy-boto3-sns==1.16.25.0  # via boto3-stubs
-mypy-boto3-sqs==1.16.25.0  # via boto3-stubs
-packaging==20.4           # via bleach
-pip-tools==5.3.1          # via -r requirements.in
+mypy-boto3-dynamodb==1.16.34.0  # via boto3-stubs
+mypy-boto3-iam==1.16.34.0  # via boto3-stubs
+mypy-boto3-sns==1.16.34.0  # via boto3-stubs
+mypy-boto3-sqs==1.16.34.0  # via boto3-stubs
+packaging==20.7           # via bleach
+pip-tools==5.4.0          # via -r requirements.in
 pkginfo==1.6.1            # via twine
-policyuniverse==1.3.2.20201112  # via -r requirements.in
-pydantic==1.7.2           # via -r requirements.in
-pygments==2.7.2           # via readme-renderer
+policyuniverse==1.3.2.20201201  # via -r requirements.in
+pydantic==1.7.3           # via -r requirements.in
+pygments==2.7.3           # via readme-renderer
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via botocore
 pytz==2020.4              # via -r requirements.in
@@ -44,10 +44,10 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.25.0          # via -r requirements.in, requests-toolbelt, twine
 rfc3986==1.4.0            # via twine
 s3transfer==0.3.3         # via boto3
-six==1.15.0               # via bleach, cloudaux, import-string, packaging, pip-tools, python-dateutil, readme-renderer
+six==1.15.0               # via bleach, cloudaux, import-string, pip-tools, python-dateutil, readme-renderer
 tabulate==0.8.7           # via -r requirements.in
 tabview==1.4.4            # via -r requirements.in
-tqdm==4.52.0              # via -r requirements.in, twine
+tqdm==4.54.1              # via -r requirements.in, twine
 twine==3.2.0              # via -r requirements.in
 typing-extensions==3.7.4.3  # via boto3-stubs, mypy-boto3-dynamodb, mypy-boto3-iam, mypy-boto3-sns, mypy-boto3-sqs
 urllib3==1.26.2           # via botocore, requests


### PR DESCRIPTION
This PR refactors the role model so the logic for data retrieval and persistence is more self-contained. There will be a follow-up to use these new methods throughout the codebase.