### PR TITLE
Return IDs of items seeded into datasources

### DIFF
--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -58,9 +58,10 @@ def _update_role_cache(
     access_advisor_datasource = AccessAdvisorDatasource()
     access_advisor_datasource.seed(account_number)
     iam_datasource = IAMDatasource()
-    iam_datasource.seed(account_number)
+    role_ids = iam_datasource.seed(account_number)
 
-    roles = RoleList([Role(**rd) for rd in iam_datasource.values()])
+    # We only iterate over the newly-seeded data (`role_ids`) so we don't duplicate work for runs on multiple accounts
+    roles = RoleList([Role(**iam_datasource[role_id]) for role_id in role_ids])
 
     LOGGER.info("Updating role data for account {}".format(account_number))
     for role in tqdm(roles):

--- a/repokid/datasource/access_advisor.py
+++ b/repokid/datasource/access_advisor.py
@@ -15,6 +15,7 @@
 import logging
 from typing import Any
 from typing import Dict
+from typing import KeysView
 from typing import Optional
 
 import requests
@@ -101,6 +102,7 @@ class AccessAdvisorDatasource(DatasourcePlugin[str, AccessAdvisorEntry], Singlet
             return result
         raise NotFoundError
 
-    def seed(self, account_number: str) -> None:
+    def seed(self, account_number: str) -> KeysView[str]:
         aa_data = self._fetch(account_number=account_number)
         self._data.update(aa_data)
+        return aa_data.keys()

--- a/repokid/datasource/iam.py
+++ b/repokid/datasource/iam.py
@@ -15,6 +15,7 @@
 import copy
 import logging
 from typing import Dict
+from typing import KeysView
 from typing import Optional
 
 from cloudaux.aws.iam import get_account_authorization_details
@@ -52,9 +53,11 @@ class IAMDatasource(DatasourcePlugin[str, IAMEntry], Singleton):
             raise NotFoundError
         return result
 
-    def seed(self, account_number: str) -> None:
+    def seed(self, account_number: str) -> KeysView[str]:
         fetched_data = self._fetch(account_number)
+        new_keys = fetched_data.keys()
         self._data.update(fetched_data)
+        return new_keys
 
 
 # TODO: Implement retrieval of IAM data from AWS Config
@@ -65,5 +68,5 @@ class ConfigDatasource(DatasourcePlugin[str, IAMEntry], Singleton):
     def get(self, identifier: str) -> IAMEntry:
         pass
 
-    def seed(self, identifier: str) -> None:
+    def seed(self, identifier: str) -> KeysView[str]:
         pass

--- a/repokid/datasource/plugin.py
+++ b/repokid/datasource/plugin.py
@@ -58,7 +58,7 @@ class DatasourcePlugin(RepokidPlugin, Generic[KT, VT]):
     def get(self, identifier: KT) -> VT:
         raise NotImplementedError
 
-    def seed(self, identifier: KT) -> None:
+    def seed(self, identifier: KT) -> KeysView[KT]:
         raise NotImplementedError
 
     def reset(self) -> None:


### PR DESCRIPTION
This fixes a bug where running `update_role_cache()` on multiple accounts would end up duplicating work and potentially causing problems.