### PR TITLE
Add flag to fetch AA data on Role fetch

### DIFF
--- a/repokid/commands/schedule.py
+++ b/repokid/commands/schedule.py
@@ -45,6 +45,7 @@ def _schedule_repo(
         86400 * config.get("repo_schedule_period_days", 7)
     )
     for role in roles:
+        role.fetch(fetch_aa_data=True)
         if not role.aa_data:
             LOGGER.warning("Not scheduling %s; missing Access Advisor data", role.arn)
             continue

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -285,7 +285,12 @@ class Role(BaseModel):
         except NotFoundError:
             self.aa_data = []
 
-    def fetch(self, fields: Optional[List[str]] = None, update: bool = True) -> None:
+    def fetch(
+        self,
+        fields: Optional[List[str]] = None,
+        update: bool = True,
+        fetch_aa_data: bool = False,
+    ) -> None:
         if self._dirty:
             raise IntegrityError(
                 "role object has unsaved modifications, fetching may overwrite changes"
@@ -302,6 +307,8 @@ class Role(BaseModel):
                 "missing role_id or role_name and account on Role instance"
             )
 
+        if fetch_aa_data:
+            self.fetch_aa_data()
         if update:
             self.update(stored_role_data, store=False)
             self._updated_fields - set(stored_role_data.keys())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -416,6 +416,7 @@ class TestRepokidCLI(object):
 
     @patch("repokid.hooks.call_hooks")
     @patch("repokid.commands.role_cache.Role.store")
+    @patch("repokid.role.Role.fetch")
     @patch("repokid.commands.role.RoleList.from_ids")
     @patch("repokid.commands.schedule.get_all_role_ids_for_account")
     @patch("time.time")
@@ -424,6 +425,7 @@ class TestRepokidCLI(object):
         mock_time,
         mock_get_all_role_ids_for_account,
         mock_role_list_from_ids,
+        mock_fetch,
         mock_role_store,
         mock_call_hooks,
     ):


### PR DESCRIPTION
This PR helps ensure Role objects have Access Advisor data during the scheduling process.