### PR TITLE
Use ARN as key for role handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Repokid is extensible via hooks that are called before, during, and after variou
 | `AFTER_REPO_ROLES` | roles, errors |
 | `BEFORE_REPO_ROLES` | account_number, roles |
 | `AFTER_SCHEDULE_REPO` | roles |
-| `DURING_REPOABLE_CALCULATION` | role_id, account_number, role_name, potentially_repoable_permissions, minimum_age |
+| `DURING_REPOABLE_CALCULATION` | role_id, arn, account_number, role_name, potentially_repoable_permissions, minimum_age |
 | `DURING_REPOABLE_CALCULATION_BATCH` | role_batch, potentially_repoable_permissions, minimum_age |
 
 Hooks must adhere to the following interface:

--- a/repokid/commands/repo.py
+++ b/repokid/commands/repo.py
@@ -32,7 +32,7 @@ from repokid.role import RoleList
 from repokid.types import RepokidConfig
 from repokid.types import RepokidHooks
 from repokid.utils.dynamo import find_role_in_cache
-from repokid.utils.dynamo import role_ids_for_all_accounts
+from repokid.utils.dynamo import role_arns_for_all_accounts
 from repokid.utils.permissions import get_services_in_permissions
 
 LOGGER = logging.getLogger("repokid")
@@ -235,10 +235,10 @@ def _repo_all_roles(
     access_advisor_datasource = AccessAdvisorDatasource()
     access_advisor_datasource.seed(account_number)
     iam_datasource = IAMDatasource()
-    role_ids = iam_datasource.seed(account_number)
+    role_arns = iam_datasource.seed(account_number)
     errors = []
 
-    roles = RoleList.from_ids(role_ids, config=config)
+    roles = RoleList.from_arns(role_arns, config=config)
     roles = roles.get_active()
     if scheduled:
         roles = roles.get_scheduled()
@@ -296,9 +296,9 @@ def _repo_stats(output_file: str, account_number: str = "") -> None:
         access_advisor_datasource = AccessAdvisorDatasource()
         access_advisor_datasource.seed(account_number)
         iam_datasource = IAMDatasource()
-        role_ids = iam_datasource.seed(account_number)
+        role_arns = iam_datasource.seed(account_number)
     else:
-        role_ids = role_ids_for_all_accounts()
+        role_arns = role_arns_for_all_accounts()
 
     headers = [
         "RoleId",
@@ -312,8 +312,8 @@ def _repo_stats(output_file: str, account_number: str = "") -> None:
         "Disqualified By",
     ]
     rows = []
-    roles = RoleList.from_ids(
-        role_ids, fields=["RoleId", "RoleName", "Account", "Active", "Stats"]
+    roles = RoleList.from_arns(
+        role_arns, fields=["RoleId", "RoleName", "Account", "Active", "Stats"]
     )
 
     for role in roles:

--- a/repokid/commands/role.py
+++ b/repokid/commands/role.py
@@ -31,7 +31,7 @@ from repokid.types import RepokidConfig
 from repokid.types import RepokidHooks
 from repokid.utils.dynamo import find_role_in_cache
 from repokid.utils.dynamo import get_all_role_ids_for_account
-from repokid.utils.dynamo import role_ids_for_all_accounts
+from repokid.utils.dynamo import role_arns_for_all_accounts
 from repokid.utils.iam import inline_policies_size_exceeds_maximum
 from repokid.utils.permissions import get_permissions_in_policy
 from repokid.utils.permissions import get_services_in_permissions
@@ -106,7 +106,7 @@ def _find_roles_with_permissions(permissions: List[str], output_file: str) -> No
         None
     """
     arns: List[str] = list()
-    role_ids = role_ids_for_all_accounts()
+    role_ids = role_arns_for_all_accounts()
     roles = RoleList.from_ids(
         role_ids, fields=["Policies", "RoleName", "Arn", "Active"]
     )

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -18,7 +18,6 @@ from tqdm import tqdm
 from repokid.datasource.access_advisor import AccessAdvisorDatasource
 from repokid.datasource.iam import IAMDatasource
 from repokid.filters.utils import get_filter_plugins
-from repokid.role import Role
 from repokid.role import RoleList
 from repokid.types import RepokidConfig
 from repokid.types import RepokidHooks
@@ -58,10 +57,10 @@ def _update_role_cache(
     access_advisor_datasource = AccessAdvisorDatasource()
     access_advisor_datasource.seed(account_number)
     iam_datasource = IAMDatasource()
-    role_ids = iam_datasource.seed(account_number)
+    role_arns = iam_datasource.seed(account_number)
 
-    # We only iterate over the newly-seeded data (`role_ids`) so we don't duplicate work for runs on multiple accounts
-    roles = RoleList([Role(**iam_datasource[role_id]) for role_id in role_ids])
+    # We only iterate over the newly-seeded data (`role_arns`) so we don't duplicate work for runs on multiple accounts
+    roles = RoleList.from_arns(role_arns)
 
     LOGGER.info("Updating role data for account {}".format(account_number))
     for role in tqdm(roles):

--- a/repokid/datasource/iam.py
+++ b/repokid/datasource/iam.py
@@ -43,7 +43,7 @@ class IAMDatasource(DatasourcePlugin[str, IAMEntry], metaclass=Singleton):
         conn["account_number"] = account_number
         auth_details = get_account_authorization_details(filter="Role", **conn)
         auth_details_by_id = {item["Arn"]: item for item in auth_details}
-        self._arn_to_id.update({item["RoleId"]: item["Arn"] for item in auth_details})
+        self._arn_to_id.update({item["Arn"]: item["RoleId"] for item in auth_details})
         # convert policies list to dictionary to maintain consistency with old call which returned a dict
         for _, data in auth_details_by_id.items():
             data["RolePolicyList"] = {

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -116,13 +116,15 @@ class Role(BaseModel):
         underscore_attrs_are_private = True
 
     def __eq__(self, other: object) -> bool:
-        return self.role_id == other
+        if not self.arn:
+            return False
+        return self.arn == other
 
     def __hash__(self) -> int:
-        return hash(self.role_id)
+        return hash(self.arn)
 
     def __repr__(self) -> str:
-        return f"<Role {self.role_id}>"
+        return f"<{self.arn}>"
 
     @root_validator(pre=True)
     def derive_from_arn(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -335,7 +337,7 @@ class Role(BaseModel):
     def _fetch_iam_data(self) -> IAMEntry:
         iam_datasource = IAMDatasource()
         role_data = iam_datasource.get(self.arn)
-        role_id = iam_datasource.get_id_for_arn(self.arn)
+        role_id = role_data.get("RoleId")
         if role_id:
             self.role_id = role_id
         return role_data
@@ -659,7 +661,7 @@ class RoleList(object):
         return len(self.roles)
 
     def __repr__(self) -> str:
-        return str([role.role_id for role in self.roles])
+        return str([role.arn for role in self.roles])
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, RoleList):

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -33,6 +33,7 @@ from dateutil.parser import parse as ts_parse
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import PrivateAttr
+from pydantic import root_validator
 from pydantic import validator
 
 from repokid import CONFIG
@@ -50,8 +51,8 @@ from repokid.types import IAMEntry
 from repokid.types import RepokidConfig
 from repokid.types import RepokidHooks
 from repokid.utils.dynamo import create_dynamodb_entry
+from repokid.utils.dynamo import get_role_by_arn
 from repokid.utils.dynamo import get_role_by_id
-from repokid.utils.dynamo import get_role_by_name
 from repokid.utils.dynamo import set_role_data
 from repokid.utils.iam import delete_policy
 from repokid.utils.iam import inline_policies_size_exceeds_maximum
@@ -123,9 +124,25 @@ class Role(BaseModel):
     def __repr__(self) -> str:
         return f"<Role {self.role_id}>"
 
+    @root_validator(pre=True)
+    def derive_from_arn(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        arn = values.get("arn") or values.get("Arn")
+        account = values.get("account") or values.get("Account")
+        role_name = values.get("role_name") or values.get("RoleName")
+        if arn and not account:
+            values["account"] = arn.split(":")[4]
+        if arn and not role_name:
+            values["role_name"] = arn.split("/")[-1]
+        if account and role_name and not arn:
+            values["arn"] = f"arn:aws:iam::{account}:role/{role_name}"
+        return values
+
     @validator("create_date")
-    def datetime_normalize(cls, v: datetime.datetime) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(v.timestamp())
+    def datetime_normalize(cls, v: datetime.datetime) -> Optional[datetime.datetime]:
+        if isinstance(v, datetime.datetime):
+            return datetime.datetime.fromtimestamp(v.timestamp())
+        else:
+            return None
 
     @validator("config")
     def fix_none_config(cls, v: Optional[RepokidConfig]) -> RepokidConfig:
@@ -173,6 +190,7 @@ class Role(BaseModel):
             return
         repoable_permissions = get_repoable_permissions(
             self.account,
+            self.arn,
             self.role_name,
             all_permissions,
             self.aa_data,
@@ -316,8 +334,11 @@ class Role(BaseModel):
 
     def _fetch_iam_data(self) -> IAMEntry:
         iam_datasource = IAMDatasource()
-        role_data = iam_datasource.get(self.role_id)
-        return role_data.get("RolePolicyList", [])
+        role_data = iam_datasource.get(self.arn)
+        role_id = iam_datasource.get_id_for_arn(self.arn)
+        if role_id:
+            self.role_id = role_id
+        return role_data
 
     def fetch(
         self,
@@ -332,10 +353,8 @@ class Role(BaseModel):
 
         if self.role_id:
             stored_role_data = get_role_by_id(self.role_id, fields=fields)
-        elif self.role_name and self.account:
-            stored_role_data = get_role_by_name(
-                self.account, self.role_name, fields=fields
-            )
+        elif self.arn:
+            stored_role_data = get_role_by_arn(self.arn, fields=fields)
         else:
             # TODO: we can pull role_name and account from an ARN, support that too
             raise ModelError(
@@ -356,7 +375,7 @@ class Role(BaseModel):
     def store(self, fields: Optional[List[str]] = None) -> None:
         create = False
         try:
-            remote_role_data = Role(role_id=self.role_id)
+            remote_role_data = Role(role_id=self.role_id, arn=self.arn)
             remote_role_data.fetch(fields=["LastUpdated"])
             if (
                 remote_role_data.last_updated
@@ -672,6 +691,22 @@ class RoleList(object):
     ) -> RoleList:
         role_list = cls(
             [Role(role_id=role_id, config=config) for role_id in id_list], config=config
+        )
+        if fetch:
+            role_list.fetch_all(fetch_aa_data=fetch_aa_data, fields=fields)
+        return role_list
+
+    @classmethod
+    def from_arns(
+        cls,
+        arn_list: Iterable[str],
+        fetch: bool = True,
+        fetch_aa_data: bool = True,
+        fields: Optional[List[str]] = None,
+        config: Optional[RepokidConfig] = None,
+    ) -> RoleList:
+        role_list = cls(
+            [Role(arn=arn, config=config) for arn in arn_list], config=config
         )
         if fetch:
             role_list.fetch_all(fetch_aa_data=fetch_aa_data, fields=fields)

--- a/repokid/utils/permissions.py
+++ b/repokid/utils/permissions.py
@@ -115,6 +115,7 @@ def get_services_and_permissions_from_repoable(
 
 def get_repoable_permissions(
     account_number: str,
+    arn: str,
     role_name: str,
     permissions: Set[str],
     aa_data: List[Dict[str, Any]],
@@ -164,6 +165,7 @@ def get_repoable_permissions(
             "potentially_repoable_permissions": potentially_repoable_permissions,
             "minimum_age": minimum_age,
             "role_id": role_id,
+            "arn": arn,
         },
     )
 

--- a/tests/datasource/test_iam.py
+++ b/tests/datasource/test_iam.py
@@ -15,9 +15,11 @@ def test_iam_get():
     assert result == expected
 
 
-def test_iam_get_fallback_not_found():
+@patch("repokid.datasource.iam.IAMDatasource._fetch")
+def test_iam_get_fallback_not_found(mock_fetch):
+    mock_fetch.side_effect = NotFoundError
     ds = IAMDatasource()
-    arn = "pretend_arn"
+    arn = "arn:aws:iam::12345678901:role/test"
     with pytest.raises(NotFoundError):
         _ = ds.get(arn)
 

--- a/tests/test_permissions.py.bak
+++ b/tests/test_permissions.py.bak
@@ -1,0 +1,401 @@
+#  Copyright 2021 Netflix, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from repokid.utils.permissions import (
+    remove_actions_from_policies,
+    tidy_policies,
+    get_repoed_policies_v2,
+)
+
+
+def test_remove_actions_from_policies():
+    """
+    This tests a few things:
+     - removing an entire service
+     - removing an individual action
+     - removing a subset of an expanded wildcard action
+     - removing all of an expanded wildcard action
+     - ensuring NOREPO policy statements are not touched
+     - ensuring Deny policy statements are not touched
+    """
+    repoable_permissions = {
+        "ec2",
+        "sqs:sendmessage",
+        "sqs:changemessagevisibilitybatch",
+    }
+    policies = {
+        "partial_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                        "sqs:Change*",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Deny",
+                    "Sid": "test-deny",
+                    "Action": [
+                        "iam:Create*",
+                    ],
+                },
+            ],
+        },
+        "full_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                    ],
+                },
+            ],
+        },
+        "no_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+            ],
+        },
+    }
+    expected_policies = {
+        "partial_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:changemessagevisibility",
+                        "sqs:getmessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Deny",
+                    "Sid": "test-deny",
+                    "Action": [
+                        "iam:Create*",
+                    ],
+                },
+            ],
+        },
+        "full_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [],
+                },
+            ],
+        },
+        "no_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:getmessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+            ],
+        },
+    }
+    result = remove_actions_from_policies(
+        policies, repoable_permissions, exclude_prefix="NOREPO"
+    )
+    assert result == expected_policies
+
+
+def test_tidy_policies():
+    policies = {
+        "partial_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Deny",
+                    "Sid": "test-deny",
+                    "Action": [
+                        "iam:Create*",
+                    ],
+                },
+            ],
+        },
+        "full_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [],
+                },
+            ],
+        },
+        "no_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:getmessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+            ],
+        },
+    }
+    expected_policies = {
+        "partial_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Deny",
+                    "Sid": "test-deny",
+                    "Action": [
+                        "iam:Create*",
+                    ],
+                },
+            ],
+        },
+        "full_repo_policy": {
+            "Statement": [],
+        },
+        "no_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:getmessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+            ],
+        },
+    }
+    expected_empty_policy_names = ["full_repo_policy"]
+    tidied_policies, empty_policy_names = tidy_policies(policies)
+    assert tidied_policies == expected_policies
+    assert empty_policy_names == expected_empty_policy_names
+
+
+def test_get_repoed_policies_v2():
+    repoable_permissions = {
+        "ec2",
+        "sqs:sendmessage",
+        "sqs:changemessagevisibilitybatch",
+    }
+    policies = {
+        "partial_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                        "sqs:Change*",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:SendMessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Deny",
+                    "Sid": "test-deny",
+                    "Action": [
+                        "iam:Create*",
+                    ],
+                },
+            ],
+        },
+        "full_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                    ],
+                },
+            ],
+        },
+        "no_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:GetMessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+            ],
+        },
+    }
+    expected_policies = {
+        "partial_repo_policy": {
+            "Statement": [
+                {
+                    "Action": ["sqs:changemessagevisibility", "sqs:getmessage"],
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                },
+                {
+                    "Action": ["ec2:Describe*", "sqs:SendMessage", "sqs:GetMessage"],
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                },
+                {
+                    "Effect": "Deny",
+                    "Sid": "test-deny",
+                    "Action": [
+                        "iam:Create*",
+                    ],
+                },
+            ],
+        },
+        "full_repo_policy": {
+            "Statement": [],
+        },
+        "no_repo_policy": {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Sid": "test-sid",
+                    "Action": [
+                        "sqs:getmessage",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Sid": "NOREPOtest-sid",
+                    "Action": [
+                        "ec2:Describe*",
+                        "sqs:SendMessage",
+                        "sqs:GetMessage",
+                    ],
+                },
+            ],
+        },
+    }
+    expected_empty_policy_names = ["full_repo_policy"]
+    repoed_policies, empty_policy_names = get_repoed_policies_v2(
+        policies, repoable_permissions
+    )
+    assert repoed_policies == expected_policies
+    assert empty_policy_names == expected_empty_policy_names

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -460,6 +460,7 @@ def test_role_fetch_aa_data(mock_seed_aardvark_data, mock_get_aardvark_data, rol
 def test_role_fetch_aa_data_no_arn(role_dict):
     role_data = copy.deepcopy(role_dict)
     role_data.pop("arn")
+    role_data.pop("account")
     r = Role(**role_data)
     with pytest.raises(ModelError):
         r.fetch_aa_data()
@@ -476,11 +477,11 @@ def test_role_fetch(mock_get_role_by_id, role_dict):
     assert r.repoable_permissions == 20
 
 
-@patch("repokid.role.get_role_by_name")
-def test_role_fetch_no_id(mock_get_role_by_name, role_dict):
+@patch("repokid.role.get_role_by_arn")
+def test_role_fetch_no_id(mock_get_role_by_arn, role_dict):
     stored_role_data = copy.deepcopy(role_dict)
     stored_role_data["repoable_permissions"] = 20
-    mock_get_role_by_name.return_value = stored_role_data
+    mock_get_role_by_arn.return_value = stored_role_data
     local_role_data = copy.deepcopy(role_dict)
     local_role_data.pop("role_id")
     r = Role(**local_role_data)
@@ -495,7 +496,7 @@ def test_role_fetch_not_found(role_dict):
     local_role_data.pop("role_name")
     local_role_data.pop("account")
     r = Role(**local_role_data)
-    with pytest.raises(ModelError):
+    with pytest.raises(RoleNotFoundError):
         r.fetch()
 
 

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -490,7 +490,9 @@ def test_role_fetch_no_id(mock_get_role_by_arn, role_dict):
     assert r.repoable_permissions == 20
 
 
-def test_role_fetch_not_found(role_dict):
+@patch("repokid.role.get_role_by_arn")
+def test_role_fetch_not_found(mock_get_role_by_arn, role_dict):
+    mock_get_role_by_arn.side_effect = RoleNotFoundError
     local_role_data = copy.deepcopy(role_dict)
     local_role_data.pop("role_id")
     local_role_data.pop("role_name")


### PR DESCRIPTION
Switch to using ARNs as the primary key instead of RoleId. This makes it easier to interact with RepoKid on an ad hoc basis.

Some things to note:
* The IAM datasource can be used without seeding (yay!). This was a big motivator for this change. The datasource will fall back to an IAM get_role call instead of requiring the get_account_authorization_details call for every run. You should still seed the datasource if you're interacting with more than a handful of roles in an account.
* Role instantiation makes some assumptions about conversions between ARN and account/role name. This can be found in `Role.derive_from_arn()`.
* `DURING_REPOABLE_CALCULATION` hooks now get `arn` in their input dict.
* ⚠️ A new DynamoDB index is added to support keying off of ARNs. This prompted a bit of refactoring in the table creation logic to update existing tables with the new index. There may be dragons here.
