### PR TITLE
Bugfix/excluding diqualified by during update

### DIFF
--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -87,7 +87,9 @@ def _update_role_cache(
             filtered_role.disqualified_by = list(disqualified_by)
 
     for role in roles:
-        role.calculate_repo_scores(config["filter_config"]["AgeFilter"]["minimum_age"], hooks)
+        role.calculate_repo_scores(
+            config["filter_config"]["AgeFilter"]["minimum_age"], hooks
+        )
         LOGGER.debug(
             "Role {} in account {} has\nrepoable permissions: {}\nrepoable services: {}".format(
                 role.role_name,

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -87,6 +87,7 @@ def _update_role_cache(
             filtered_role.disqualified_by = list(disqualified_by)
 
     for role in roles:
+        role.calculate_repo_scores(config["filter_config"]["AgeFilter"]["minimum_age"], hooks)
         LOGGER.debug(
             "Role {} in account {} has\nrepoable permissions: {}\nrepoable services: {}".format(
                 role.role_name,

--- a/repokid/commands/role_cache.py
+++ b/repokid/commands/role_cache.py
@@ -66,6 +66,8 @@ def _update_role_cache(
     for role in tqdm(roles):
         role.account = account_number
         role.gather_role_data(hooks, config=config, source="Scan", store=False)
+        # Reseting previous filters
+        role.disqualified_by = list()
 
     LOGGER.info("Finding inactive roles in account {}".format(account_number))
     find_and_mark_inactive(account_number, roles)

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -343,7 +343,7 @@ class Role(BaseModel):
         self._updated_fields.update(values.keys())
         temp_role = Role(**values)
         role_data = temp_role.dict(
-            exclude_unset=True, exclude={"config", "_dirty", "_updated_fields", "disqualified_by"}
+            exclude_unset=True, exclude={"config", "_dirty", "_updated_fields"}
         )
         for k, v in role_data.items():
             setattr(self, k, v)
@@ -809,7 +809,7 @@ class RoleList(object):
             [
                 role
                 for role in self.roles
-                if (role.repo_scheduled and cur_time > role.repo_scheduled)
+                if (role.repo_scheduled and cur_time < role.repo_scheduled)
             ]
         )
 

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -809,7 +809,7 @@ class RoleList(object):
             [
                 role
                 for role in self.roles
-                if (role.repo_scheduled and cur_time < role.repo_scheduled)
+                if (role.repo_scheduled and cur_time > role.repo_scheduled)
             ]
         )
 

--- a/repokid/role.py
+++ b/repokid/role.py
@@ -343,7 +343,7 @@ class Role(BaseModel):
         self._updated_fields.update(values.keys())
         temp_role = Role(**values)
         role_data = temp_role.dict(
-            exclude_unset=True, exclude={"config", "_dirty", "_updated_fields"}
+            exclude_unset=True, exclude={"config", "_dirty", "_updated_fields", "disqualified_by"}
         )
         for k, v in role_data.items():
             setattr(self, k, v)


### PR DESCRIPTION
We started to use Repokid internally at FollowAnalytics and we found a weird behavior when playing with the filters.
In this PR we propose to share the changes we made in our forked project.
Bellow I'll describe how you can reproduce it:

1. Add a filter in the config file to disqualify your test role (we'll call it RoleTest), you can use age filter for example.
2. Run the command to update the role cache and verify that the _disqualified by_ list is not empty for RoleTest.
3. Change the config file to make the RoleTest eligible.
4. Run the command to update the role cache.
5. The expected is to have an empty list in _disqualified by_ but it keeps the filter applied previously.

In this PR we propose to reset the _disqualified by_ list before the filter application. We also added the function _calculate_repo_scores_ to have the repoable policies of the roles recently became eligible during the filter application. 