### PR TITLE
Fix active check when multiple results found in DDB

### DIFF
--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -270,9 +270,10 @@ def get_role_by_arn(
 
     if len(items) > 1:
         # multiple results, so we'll grab the first match that's active
-        for r in items:
-            if r.get("Active") and isinstance(r, dict):
-                return r
+        logger.warning("found multiple results for %s in DynamoDB", arn)
+        for item in items:
+            if item.get("Active", "").lower() == "true":
+                return item  # type: ignore
 
     # we only have one result
     if not isinstance(items[0], dict):


### PR DESCRIPTION
This PR fixes a bug in which the active check on a role would always evaluate to `True` if any value was present (e.g. `"false"` or `"potatoes"`), thus returning the first item in the query results.